### PR TITLE
Adopted "official" ICARUS namespace spelling

### DIFF
--- a/larwirecell/Modules/Geometry/CTreeGeometry_module.cc
+++ b/larwirecell/Modules/Geometry/CTreeGeometry_module.cc
@@ -63,7 +63,7 @@
 
 using namespace std;
 
-namespace icarus {
+namespace {
 
 class CTreeGeometry : public art::EDAnalyzer {
 public:

--- a/larwirecell/Modules/Geometry/CTreeGeometry_module.cc
+++ b/larwirecell/Modules/Geometry/CTreeGeometry_module.cc
@@ -63,7 +63,7 @@
 
 using namespace std;
 
-namespace ICARUS{
+namespace icarus {
 
 class CTreeGeometry : public art::EDAnalyzer {
 public:


### PR DESCRIPTION
This appears to be the only appearance of namespace `ICARUS` in LArSoft (according to Doxygen).
The official spelling is in small letters. And it does not even matter since this is a module and its namespace is basically not used anywhere. But it does make all appearances of "ICARUS" word in `icaruscode` Doxygen refer to this module.
So I am proposing to change it.

This is another GitHub-based commit. I wear I did not choose the name of the branch.

The file was authored by @wenqiang-gu, who is likely the person who can express opinions about the change.