### PR TITLE
Interface changes for WCT 0.22.0

### DIFF
--- a/larwirecell/Components/CookedFrameSource.cxx
+++ b/larwirecell/Components/CookedFrameSource.cxx
@@ -6,8 +6,8 @@
 
 #include "TTimeStamp.h"
 
-#include "WireCellIface/SimpleFrame.h"
-#include "WireCellIface/SimpleTrace.h"
+#include "WireCellAux/SimpleFrame.h"
+#include "WireCellAux/SimpleTrace.h"
 #include "WireCellUtil/NamedFactory.h"
 
 WIRECELL_FACTORY(wclsCookedFrameSource,
@@ -17,6 +17,8 @@ WIRECELL_FACTORY(wclsCookedFrameSource,
 
 using namespace wcls;
 using namespace WireCell;
+using WireCell::Aux::SimpleTrace;
+using WireCell::Aux::SimpleFrame;
 
 CookedFrameSource::CookedFrameSource() : m_nticks(0) {}
 
@@ -121,7 +123,7 @@ CookedFrameSource::visit(art::Event& e)
   }
 
   const double time = tdiff(event.getRun().beginTime(), event.time());
-  auto sframe = new WireCell::SimpleFrame(event.event(), time, traces, tick);
+  auto sframe = new SimpleFrame(event.event(), time, traces, tick);
   for (auto tag : m_frame_tags) {
     //std::cerr << "\ttagged: " << tag << std::endl;
     sframe->tag_frame(tag);

--- a/larwirecell/Components/RawFrameSource.cxx
+++ b/larwirecell/Components/RawFrameSource.cxx
@@ -9,8 +9,8 @@
 #include "TTimeStamp.h"
 
 
-#include "WireCellIface/SimpleFrame.h"
-#include "WireCellIface/SimpleTrace.h"
+#include "WireCellAux/SimpleFrame.h"
+#include "WireCellAux/SimpleTrace.h"
 #include "WireCellUtil/NamedFactory.h"
 
 WIRECELL_FACTORY(wclsRawFrameSource, wcls::RawFrameSource,
@@ -19,6 +19,8 @@ WIRECELL_FACTORY(wclsRawFrameSource, wcls::RawFrameSource,
 
 using namespace wcls;
 using namespace WireCell;
+using WireCell::Aux::SimpleTrace;
+using WireCell::Aux::SimpleFrame;
 
 RawFrameSource::RawFrameSource()
     : m_nticks(0)
@@ -132,7 +134,7 @@ void RawFrameSource::visit(art::Event & event)
     }
 
     const double time = tdiff(event.getRun().beginTime(), event.time());
-    auto sframe = new WireCell::SimpleFrame(event.event(), time, traces, tick);
+    auto sframe = new SimpleFrame(event.event(), time, traces, tick);
     for (auto tag : m_frame_tags) {
         //std::cerr << "\ttagged: " << tag << std::endl;
         sframe->tag_frame(tag);

--- a/larwirecell/Components/SimDepoSetSource.cxx
+++ b/larwirecell/Components/SimDepoSetSource.cxx
@@ -12,13 +12,15 @@
 #include "WireCellUtil/Units.h"
 #include "WireCellUtil/String.h"
 #include "WireCellUtil/NamedFactory.h"
-#include "WireCellIface/SimpleDepo.h"
-#include "WireCellIface/SimpleDepoSet.h"
+#include "WireCellAux/SimpleDepo.h"
+#include "WireCellAux/SimpleDepoSet.h"
 #include "WireCellIface/IRecombinationModel.h"
 
 WIRECELL_FACTORY(wclsSimDepoSetSource, wcls::SimDepoSetSource, wcls::IArtEventVisitor,
                  WireCell::IDepoSetSource, WireCell::IConfigurable)
 
+using WireCell::Aux::SimpleDepo;
+using WireCell::Aux::SimpleDepoSet;
 
 namespace units = WireCell::units;
 
@@ -207,7 +209,7 @@ void SimDepoSetSource::visit(art::Event & event)
 
         if (assn_sedv.size() == 0) {
             WireCell::IDepo::pointer depo
-                = std::make_shared<WireCell::SimpleDepo>(wt, wpt, wq, nullptr, 0.0, 0.0, wid, pdg, we);
+                = std::make_shared<SimpleDepo>(wt, wpt, wq, nullptr, 0.0, 0.0, wid, pdg, we);
             m_depos.push_back(depo);
             // std::cerr << ind << ": t=" << wt/units::us << "us,"
             //           << " r=" << wpt/units::cm << "cm, "
@@ -225,10 +227,10 @@ void SimDepoSetSource::visit(art::Event & event)
             double we1 = sed1.Energy()*units::MeV;
 
             WireCell::IDepo::pointer assn_depo
-            = std::make_shared<WireCell::SimpleDepo>(wt1, wpt1, wq1, nullptr, 0.0, 0.0, wid1, pdg1, we1);
+            = std::make_shared<SimpleDepo>(wt1, wpt1, wq1, nullptr, 0.0, 0.0, wid1, pdg1, we1);
 
             WireCell::IDepo::pointer depo
-                = std::make_shared<WireCell::SimpleDepo>(wt, wpt, wq, assn_depo, 0.0, 0.0, wid, pdg, we);
+                = std::make_shared<SimpleDepo>(wt, wpt, wq, assn_depo, 0.0, 0.0, wid, pdg, we);
             m_depos.push_back(depo);
             // std::cerr << ind << ": t1=" << wt1/units::us << "us,"
             //           << " r1=" << wpt1/units::cm << "cm, "
@@ -241,7 +243,7 @@ void SimDepoSetSource::visit(art::Event & event)
     if (ndepos == 0) {
 	    WireCell::Point wpt(0, 0, 0);
 	    WireCell::IDepo::pointer depo
-		    = std::make_shared<WireCell::SimpleDepo>(0, wpt, 0, nullptr, 0.0, 0.0);
+		    = std::make_shared<SimpleDepo>(0, wpt, 0, nullptr, 0.0, 0.0);
 	    m_depos.push_back(depo);
     }
 
@@ -258,7 +260,7 @@ bool SimDepoSetSource::operator()(WireCell::IDepoSet::pointer& out)
         return false;
     }
 
-    out = std::make_shared<WireCell::SimpleDepoSet>(m_count, m_depos);
+    out = std::make_shared<SimpleDepoSet>(m_count, m_depos);
     m_depos.clear();
     ++m_count;
 

--- a/larwirecell/Components/SimDepoSource.cxx
+++ b/larwirecell/Components/SimDepoSource.cxx
@@ -16,12 +16,13 @@
 #include "WireCellUtil/Units.h"
 #include "WireCellUtil/String.h"
 #include "WireCellUtil/NamedFactory.h"
-#include "WireCellIface/SimpleDepo.h"
+#include "WireCellAux/SimpleDepo.h"
 #include "WireCellIface/IRecombinationModel.h"
 
 WIRECELL_FACTORY(wclsSimDepoSource, wcls::SimDepoSource, wcls::IArtEventVisitor,
                  WireCell::IDepoSource, WireCell::IConfigurable)
 
+using WireCell::Aux::SimpleDepo;
 
 namespace units = WireCell::units;
 
@@ -209,7 +210,7 @@ void SimDepoSource::visit(art::Event & event)
 
         if (assn_sedv.size() == 0) {
             WireCell::IDepo::pointer depo
-                = std::make_shared<WireCell::SimpleDepo>(wt, wpt, wq, nullptr, 0.0, 0.0, wid, pdg, we);
+                = std::make_shared<SimpleDepo>(wt, wpt, wq, nullptr, 0.0, 0.0, wid, pdg, we);
             m_depos.push_back(depo);
             // std::cerr << ind << ": t=" << wt/units::us << "us,"
             //           << " r=" << wpt/units::cm << "cm, "
@@ -227,10 +228,10 @@ void SimDepoSource::visit(art::Event & event)
             double we1 = sed1.Energy()*units::MeV;
 
             WireCell::IDepo::pointer assn_depo
-            = std::make_shared<WireCell::SimpleDepo>(wt1, wpt1, wq1, nullptr, 0.0, 0.0, wid1, pdg1, we1);
+            = std::make_shared<SimpleDepo>(wt1, wpt1, wq1, nullptr, 0.0, 0.0, wid1, pdg1, we1);
 
             WireCell::IDepo::pointer depo
-                = std::make_shared<WireCell::SimpleDepo>(wt, wpt, wq, assn_depo, 0.0, 0.0, wid, pdg, we);
+                = std::make_shared<SimpleDepo>(wt, wpt, wq, assn_depo, 0.0, 0.0, wid, pdg, we);
             m_depos.push_back(depo);
             // std::cerr << ind << ": t1=" << wt1/units::us << "us,"
             //           << " r1=" << wpt1/units::cm << "cm, "
@@ -243,7 +244,7 @@ void SimDepoSource::visit(art::Event & event)
     if (ndepos == 0) {
 	    WireCell::Point wpt(0, 0, 0);
 	    WireCell::IDepo::pointer depo
-		    = std::make_shared<WireCell::SimpleDepo>(0, wpt, 0, nullptr, 0.0, 0.0);
+		    = std::make_shared<SimpleDepo>(0, wpt, 0, nullptr, 0.0, 0.0);
 	    m_depos.push_back(depo);
     }
 

--- a/larwirecell/LArInterface/WireCellNoiseFilter_module.cc
+++ b/larwirecell/LArInterface/WireCellNoiseFilter_module.cc
@@ -21,8 +21,8 @@
 #include "WireCellUtil/Units.h"
 #include "WireCellUtil/NamedFactory.h"
 #include "WireCellIface/IDFT.h"
-#include "WireCellIface/SimpleFrame.h"
-#include "WireCellIface/SimpleTrace.h"
+#include "WireCellAux/SimpleFrame.h"
+#include "WireCellAux/SimpleTrace.h"
 #include "WireCellAux/DftTools.h"
 #include "WireCellSigProc/Microboone.h"
 #include "WireCellSigProc/OmnibusNoiseFilter.h"
@@ -32,6 +32,8 @@
 #include <string>
 
 using namespace WireCell;
+using WireCell::Aux::SimpleTrace;
+using WireCell::Aux::SimpleFrame;
 
 namespace noisefilteralg {
 
@@ -411,12 +413,12 @@ namespace noisefilteralg {
       });
 
       unsigned int chan = inputWaveforms.at(ich).Channel();
-      WireCell::SimpleTrace* st = new WireCell::SimpleTrace(chan, 0.0, charges);
+      SimpleTrace* st = new SimpleTrace(chan, 0.0, charges);
       traces.push_back(WireCell::ITrace::pointer(st));
     }
 
     //Load traces into frame
-    WireCell::SimpleFrame* sf = new WireCell::SimpleFrame(0, 0, traces);
+    SimpleFrame* sf = new SimpleFrame(0, 0, traces);
     WireCell::IFrame::pointer frame = WireCell::IFrame::pointer(sf);
     WireCell::IFrame::pointer quiet = NULL;
 

--- a/larwirecell/LArInterface/WireCellNoiseFilter_module.cc
+++ b/larwirecell/LArInterface/WireCellNoiseFilter_module.cc
@@ -34,6 +34,7 @@
 using namespace WireCell;
 using WireCell::Aux::SimpleTrace;
 using WireCell::Aux::SimpleFrame;
+using WireCell::Aux::DftTools::fwd_r2c;
 
 namespace noisefilteralg {
 
@@ -264,8 +265,8 @@ namespace noisefilteralg {
     }
     // WireCell::Waveform::compseq_t u_resp_freq = WireCell::Waveform::dft(u_resp);
     // WireCell::Waveform::compseq_t v_resp_freq = WireCell::Waveform::dft(v_resp);
-    WireCell::Waveform::compseq_t u_resp_freq = Aux::fwd_r2c(m_dft, u_resp);
-    WireCell::Waveform::compseq_t v_resp_freq = Aux::fwd_r2c(m_dft, v_resp);
+    WireCell::Waveform::compseq_t u_resp_freq = fwd_r2c(m_dft, u_resp);
+    WireCell::Waveform::compseq_t v_resp_freq = fwd_r2c(m_dft, v_resp);
 
     int uplane_time_shift = 79;
     int vplane_time_shift = 82;


### PR DESCRIPTION
To accompany interface changes for WCT 0.21.0 (PR163) and 0.22.0 (PR172)
https://github.com/WireCell/wire-cell-toolkit/releases
This needs `wirecell` `0.22.0` to work:
https://cdcvs.fnal.gov/redmine/issues/27211
