### PR TITLE
Empty CMM bugfix + skip frame in FrameSaver

### DIFF
--- a/larwirecell/Components/FrameSaver.cxx
+++ b/larwirecell/Components/FrameSaver.cxx
@@ -539,7 +539,9 @@ void FrameSaver::visit(art::Event& event)
   }
 
   if (m_digitize && !m_skipframe) { save_as_raw(event); }
-  else if (!m_digitize && !m_skipframe) { save_as_cooked(event); }
+  else if (!m_digitize && !m_skipframe) {
+    save_as_cooked(event);
+  }
 
   save_summaries(event);
 

--- a/larwirecell/Components/FrameSaver.h
+++ b/larwirecell/Components/FrameSaver.h
@@ -79,7 +79,7 @@ namespace wcls {
     std::unordered_map<std::string, summarizer_function> m_summary_operators;
 
     int m_nticks;
-    bool m_digitize, m_sparse, m_skipframe; 
+    bool m_digitize, m_sparse, m_skipframe;
     Json::Value m_cmms, m_pedestal_mean;
     double m_pedestal_sigma;
 

--- a/larwirecell/Components/FrameSaver.h
+++ b/larwirecell/Components/FrameSaver.h
@@ -79,7 +79,7 @@ namespace wcls {
     std::unordered_map<std::string, summarizer_function> m_summary_operators;
 
     int m_nticks;
-    bool m_digitize, m_sparse;
+    bool m_digitize, m_sparse, m_skipframe; 
     Json::Value m_cmms, m_pedestal_mean;
     double m_pedestal_sigma;
 


### PR DESCRIPTION

**CMM bugfix:**
- previously, if the FrameSaver was not able to find the configured cmm name or if the cmm was empty, no art product would be created due to the ``continue;`` line, leading to an artroot error when running. Updated to allow empty CMMs.

**Skip Frame** 
- add configurable to allow user to skip saving a frame (in other words, not have to save ``raw::RawDigits`` or ``recob::Wire``). Default behavior is ``skip_frame = false``, AKA default behavior is to save a frame. 