### PR TITLE
This is meant to address the issue reported in issue #39

### DIFF
--- a/larwirecell/Components/DepoFluxWriter.cxx
+++ b/larwirecell/Components/DepoFluxWriter.cxx
@@ -271,7 +271,7 @@ void DepoFluxWriter::visit(art::Event& event)
           const double charge = std::abs(patch(pbin, tbin));
           if (charge < 1.0) { continue; }
 
-          const unsigned int tdc = tbin + toffset_bin + m_tick_offsets[iplane];
+          const unsigned int tdc = m_tbins.center(tbin)/m_tbins.binsize() + toffset_bin + m_tick_offsets[iplane];
 
           sc.AddIonizationElectrons(
             trackID, tdc, charge, xyz_cm, energy * abs(charge / depo->charge()), origTrackID);

--- a/larwirecell/Components/DepoFluxWriter.cxx
+++ b/larwirecell/Components/DepoFluxWriter.cxx
@@ -271,7 +271,8 @@ void DepoFluxWriter::visit(art::Event& event)
           const double charge = std::abs(patch(pbin, tbin));
           if (charge < 1.0) { continue; }
 
-          const unsigned int tdc = m_tbins.center(tbin)/m_tbins.binsize() + toffset_bin + m_tick_offsets[iplane];
+          const unsigned int tdc =
+            m_tbins.center(tbin) / m_tbins.binsize() + toffset_bin + m_tick_offsets[iplane];
 
           sc.AddIonizationElectrons(
             trackID, tdc, charge, xyz_cm, energy * abs(charge / depo->charge()), origTrackID);


### PR DESCRIPTION
See https://github.com/LArSoft/larwirecell/issues/39

Generally, tbin is a short int in the range of a few "bins"... the offsets can be large (and event negative) and, if negative, will give nonsensical results for the tdc value. In comparing to the old SimChannel output module (DepoSetSimChannelSink) it seems clear that instead of simple "tbin" one really needs to substitite "m_tbins(tbin)/jm_tbins.binsize()". 

Testing with ICARUS simlations in standard form give expected results with this change. 