### PR TITLE
Update DepoFluxWriter and FrameSaver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,12 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 find_package(cetmodules REQUIRED)
-project(larwirecell VERSION 09.16.00 LANGUAGES CXX)
+project(larwirecell LANGUAGES CXX)
 
 # cetbuildtools contains our cmake modules
 
 include(CetCMakeEnv)
+set(${PROJECT_NAME}_CMAKE_PROJECT_VERSION_STRING 09.80.00-rc2)
 cet_cmake_env()
 
 cet_cmake_module_directories(Modules)

--- a/larwirecell/Components/DepoFluxWriter.cxx
+++ b/larwirecell/Components/DepoFluxWriter.cxx
@@ -80,7 +80,7 @@ void DepoFluxWriter::configure(const WireCell::Configuration& cfg)
   // externally set drift speed 
   auto ext_speed = cfg["drift_speed"];
   if (!ext_speed.empty()) {
-    m_speed = ext_speed * units::mm / units::us;
+    m_speed = ext_speed.asDouble();
   }
 
   // Anode planes.
@@ -226,7 +226,7 @@ void DepoFluxWriter::visit(art::Event& event)
       trackID = depo->id();
       if (!energy) { energy = depo->energy(); }
     }
-    if (sedvh.isValid()){
+    if (sedvh.isValid()) { // IDepo::id() is index
       const auto& sed = sedvh->at(trackID);
       trackID = sed.TrackID();
       origTrackID = sed.OrigTrackID();

--- a/larwirecell/Components/DepoFluxWriter.cxx
+++ b/larwirecell/Components/DepoFluxWriter.cxx
@@ -78,7 +78,6 @@ void DepoFluxWriter::configure(const WireCell::Configuration& cfg)
   m_speed = fr.speed;
   m_origin = fr.origin;
 
-
   // Anode planes.
   Configuration janode_names = cfg["anodes"];
   if (janode_names.isString()) {
@@ -99,7 +98,7 @@ void DepoFluxWriter::configure(const WireCell::Configuration& cfg)
   m_sed_label = get(cfg, "sed_label", m_sed_label);
   m_debug_file = get(cfg, "debug_file", m_debug_file);
 
-  // sparsity 
+  // sparsity
   m_sparse = get(cfg, "sparse", true);
 
   // time-binning
@@ -175,8 +174,8 @@ void DepoFluxWriter::visit(art::Event& event)
   std::map<unsigned int, sim::SimChannel> simchans;
 
   // if dense, initialize SimChannels
-  if (!m_sparse){
-    for (auto& anode : m_anodes){
+  if (!m_sparse) {
+    for (auto& anode : m_anodes) {
       for (auto& channel : anode->channels()) {
         simchans.try_emplace(channel, sim::SimChannel(channel));
       }

--- a/larwirecell/Components/DepoFluxWriter.cxx
+++ b/larwirecell/Components/DepoFluxWriter.cxx
@@ -228,6 +228,9 @@ void DepoFluxWriter::visit(art::Event& event)
       if (!energy) { energy = depo->energy(); }
     }
     if (sedvh.isValid()) { // IDepo::id() is index
+      if (trackID < 0 || trackID >= (int)sedvh->size()) {
+        throw cet::exception("DepoFluxWriter") << "trackID= " << trackID << " is out of bounds!\n";
+      }
       const auto& sed = sedvh->at(trackID);
       trackID = sed.TrackID();
       origTrackID = sed.OrigTrackID();

--- a/larwirecell/Components/DepoFluxWriter.h
+++ b/larwirecell/Components/DepoFluxWriter.h
@@ -41,7 +41,7 @@ namespace wcls {
     // simchan_label - name by which to save results to art::Event
     std::string m_simchan_label;
     // sparse - whether to save all channels or only those with
-    // nonzero depo charge. Default is true. 
+    // nonzero depo charge. Default is true.
     bool m_sparse;
 
     // tick - the sample time over which to integrate depo flux

--- a/larwirecell/Components/DepoFluxWriter.h
+++ b/larwirecell/Components/DepoFluxWriter.h
@@ -36,6 +36,9 @@ namespace wcls {
     std::vector<WireCell::IAnodePlane::pointer> m_anodes;
 
     // field_response - name of an IFieldResponse.
+    // If an external drift speed is specified, the m_speed will 
+    // be set to the external drift speed. Otherwise, the drift speed
+    // will be set to the drift speed in the field response.
     double m_speed{0}, m_origin{0};
 
     // simchan_label - name by which to save results to art::Event

--- a/larwirecell/Components/DepoFluxWriter.h
+++ b/larwirecell/Components/DepoFluxWriter.h
@@ -36,13 +36,13 @@ namespace wcls {
     std::vector<WireCell::IAnodePlane::pointer> m_anodes;
 
     // field_response - name of an IFieldResponse.
-    // If an external drift speed is specified, the m_speed will 
-    // be set to the external drift speed. Otherwise, the drift speed
-    // will be set to the drift speed in the field response.
     double m_speed{0}, m_origin{0};
 
     // simchan_label - name by which to save results to art::Event
     std::string m_simchan_label;
+    // sparse - whether to save all channels or only those with
+    // nonzero depo charge. Default is true. 
+    bool m_sparse;
 
     // tick - the sample time over which to integrate depo flux
     // into time bins.

--- a/larwirecell/Components/FrameSaver.cxx
+++ b/larwirecell/Components/FrameSaver.cxx
@@ -94,6 +94,8 @@ WireCell::Configuration FrameSaver::default_configuration() const
 
   // Names of channel mask maps to save, if any.
   cfg["chanmaskmaps"] = Json::arrayValue;
+  cfg["cmm_masks_suffix"] = "masks";
+  cfg["cmm_channels_suffix"] = "channels";
 
   return cfg;
 }
@@ -136,6 +138,8 @@ void FrameSaver::configure(const WireCell::Configuration& cfg)
   m_skipframe = get(cfg, "skip_frame", false);
 
   m_cmms = cfg["chanmaskmaps"];
+  m_cmm_masks_suffix = cfg["cmm_masks_suffix"].asString();
+  m_cmm_channels_suffix = cfg["cmm_channels_suffix"].asString();
 
   m_pedestal_mean = cfg["pedestal_mean"];
   m_pedestal_sigma = get(cfg, "pedestal_sigma", 0.0);
@@ -217,8 +221,8 @@ void FrameSaver::produces(art::ProducesCollector& collector)
     const std::string cmm_name = cmm.asString();
     std::cerr << "wclsFrameSaver: promising to produce channel masks named \"" << cmm_name
               << "\"\n";
-    collector.produces<channel_list>(cmm_name + "channels");
-    collector.produces<channel_masks>(cmm_name + "masks");
+    collector.produces<channel_list>(cmm_name + m_cmm_channels_suffix);
+    collector.produces<channel_masks>(cmm_name + m_cmm_masks_suffix);
   }
 }
 
@@ -499,8 +503,8 @@ void FrameSaver::save_cmms(art::Event& event)
     if (out_list->empty()) {
       std::cerr << "wclsFrameSaver: found empty channel masks for \"" << name << "\"\n";
     }
-    event.put(std::move(out_list), name + "channels");
-    event.put(std::move(out_masks), name + "masks");
+    event.put(std::move(out_list), name + m_cmm_channels_suffix);
+    event.put(std::move(out_masks), name + m_cmm_masks_suffix);
   }
 }
 
@@ -529,8 +533,8 @@ void FrameSaver::save_empty(art::Event& event)
     std::string name = jcmm.asString();
     std::unique_ptr<channel_list> out_list(new channel_list);
     std::unique_ptr<channel_masks> out_masks(new channel_masks);
-    event.put(std::move(out_list), name + "channels");
-    event.put(std::move(out_masks), name + "masks");
+    event.put(std::move(out_list), name + m_cmm_channels_suffix);
+    event.put(std::move(out_masks), name + m_cmm_masks_suffix);
   }
 }
 

--- a/larwirecell/Components/FrameSaver.cxx
+++ b/larwirecell/Components/FrameSaver.cxx
@@ -81,6 +81,7 @@ WireCell::Configuration FrameSaver::default_configuration() const
   // Summaries to output, if any
   cfg["summary_tags"] = Json::arrayValue;
   cfg["summary_scale"] = 1.0;
+  cfg["summary_suffix"] = "summary";
   // Sumaries are *per trace* quantities coming in but it is likely
   // that some (most?) consumers of the output will expect *per
   // channel* quantities.  Aggregating by channel requires some
@@ -171,6 +172,8 @@ void FrameSaver::configure(const WireCell::Configuration& cfg)
     auto jscale = cfg["summary_scale"];
     m_summary_tags.clear();
     auto jtags = cfg["summary_tags"];
+    m_summary_suffix.clear();
+    m_summary_suffix = cfg["summary_suffix"].asString();
     for (auto jtag : jtags) {
       std::string tag = jtag.asString();
 
@@ -208,7 +211,7 @@ void FrameSaver::produces(art::ProducesCollector& collector)
   }
   for (auto tag : m_summary_tags) {
     std::cerr << "wclsFrameSaver: promising to produce channel summary named \"" << tag << "\"\n";
-    collector.produces<std::vector<double>>(tag + "summary");
+    collector.produces<std::vector<double>>(tag + m_summary_suffix);
   }
   for (auto cmm : m_cmms) {
     const std::string cmm_name = cmm.asString();
@@ -460,7 +463,7 @@ void FrameSaver::save_summaries(art::Event& event)
       outsum->at(chanind) = val * scale;
       ++chanind;
     }
-    event.put(std::move(outsum), tag + "summary");
+    event.put(std::move(outsum), tag + m_summary_suffix);
   }
 }
 
@@ -519,7 +522,7 @@ void FrameSaver::save_empty(art::Event& event)
 
   for (auto stag : m_summary_tags) {
     std::unique_ptr<std::vector<double>> outsum(new std::vector<double>);
-    event.put(std::move(outsum), stag + "summary");
+    event.put(std::move(outsum), stag + m_summary_suffix);
   }
 
   for (auto jcmm : m_cmms) {

--- a/larwirecell/Components/FrameSaver.cxx
+++ b/larwirecell/Components/FrameSaver.cxx
@@ -208,7 +208,7 @@ void FrameSaver::produces(art::ProducesCollector& collector)
   }
   for (auto tag : m_summary_tags) {
     std::cerr << "wclsFrameSaver: promising to produce channel summary named \"" << tag << "\"\n";
-    collector.produces<std::vector<double>>(tag);
+    collector.produces<std::vector<double>>(tag + "summary");
   }
   for (auto cmm : m_cmms) {
     const std::string cmm_name = cmm.asString();
@@ -460,7 +460,7 @@ void FrameSaver::save_summaries(art::Event& event)
       outsum->at(chanind) = val * scale;
       ++chanind;
     }
-    event.put(std::move(outsum), tag);
+    event.put(std::move(outsum), tag + "summary");
   }
 }
 
@@ -519,7 +519,7 @@ void FrameSaver::save_empty(art::Event& event)
 
   for (auto stag : m_summary_tags) {
     std::unique_ptr<std::vector<double>> outsum(new std::vector<double>);
-    event.put(std::move(outsum), stag);
+    event.put(std::move(outsum), stag + "summary");
   }
 
   for (auto jcmm : m_cmms) {

--- a/larwirecell/Components/FrameSaver.h
+++ b/larwirecell/Components/FrameSaver.h
@@ -82,6 +82,7 @@ namespace wcls {
     int m_nticks;
     bool m_digitize, m_sparse, m_skipframe;
     Json::Value m_cmms, m_pedestal_mean;
+    std::string m_cmm_masks_suffix, m_cmm_channels_suffix;
     double m_pedestal_sigma;
 
     void save_as_raw(art::Event& event);

--- a/larwirecell/Components/FrameSaver.h
+++ b/larwirecell/Components/FrameSaver.h
@@ -73,6 +73,7 @@ namespace wcls {
 
     WireCell::IFrame::pointer m_frame;
     std::vector<std::string> m_frame_tags, m_summary_tags;
+    std::string m_summary_suffix;
     std::vector<double> m_frame_scale, m_summary_scale;
 
     typedef std::function<float(const std::vector<float>& tsvals)> summarizer_function;

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -248,7 +248,7 @@ fcldir	product_dir	fcl
 ####################################
 product		version		qual	flags		<table_format=2>
 larevt		v09_09_02
-wirecell	v0_24_1b
+wirecell	v0_25_1
 cetmodules	v3_20_00	-	only_for_build
 end_product_list
 ####################################


### PR DESCRIPTION

**FrameSaver Changes** 

- change "magic" strings to configurables for the channel mask map and summary instance names. 

-----------------------------

**DepoFluxWriter Changes**

- add an exception for when the `SimEnergyDeposit` label is set (and valid) and the depo ID is out-of-bounds. This can happen if the `SimEnergyDeposit` source module configuration is inconsistent with `DepoFluxWriter` configuration 
   - ex. `id_is_track` in `SimDepoSetSource` must be set to false if `sed_label` is set). 
- change checking the `SimEnergyDeposit` handle size to checking the handle's validity
- add configuration to save a "dense" vector of `SimChannel`s. Setting `sparse = false` allows all `SimChannels` to be saved, including those with no deposited charge. Default configuration is `sparse = true`. 

**DepoFluxWriter Validation** for SBND (not an issue, purely for documentation): 

![Screen Shot 2023-10-04 at 5 32 25 PM](https://github.com/LArSoft/larwirecell/assets/71307529/774996aa-e75d-466b-b5cb-d5f7e1019795)

Above shows effects of changing the `SimChannel` sink module from DepoSetSimChannelSink to DepoFluxWriter. Slightly different waveforms are expected due to the way that the timing offsets are now being applied to each depo, as well as the change in the definition of the binning. The effect on the charge per channel and the charge per event is on the sub-percent level, and is consistent with the expected rounding effects. 
