### PR TITLE
LArWireCell Update to enable multiple signal response simulation across the YZ Plane 

### DIFF
--- a/larwirecell/Components/DepoSetSimChannelSink.cxx
+++ b/larwirecell/Components/DepoSetSimChannelSink.cxx
@@ -99,17 +99,15 @@ void DepoSetSimChannelSink::configure(const WireCell::Configuration& cfg)
   m_g4_ref_time = get(cfg, "g4_ref_time", -4050 * units::us);
   m_use_energy = get(cfg, "use_energy", false);
   m_use_extra_sigma = get(cfg, "use_extra_sigma", false);
-  
-    m_process_planes = {0,1,2};
-  
+
+  m_process_planes = {0, 1, 2};
+
   if (cfg.isMember("process_planes")) {
     m_process_planes.clear();
     for (auto jplane : cfg["process_planes"]) {
       m_process_planes.push_back(jplane.asInt());
     }
   }
-
-
 }
 
 void DepoSetSimChannelSink::produces(art::ProducesCollector& collector)
@@ -149,10 +147,11 @@ void DepoSetSimChannelSink::save_as_simchannel(const WireCell::IDepo::pointer& d
           int iplane = plane->planeid().index();
           if (iplane < 0) continue;
 
-	    if (std::find(m_process_planes.begin(),  m_process_planes.end(), iplane) == m_process_planes.end()) {   	      
-	      continue;
-	    }
-	    	  
+          if (std::find(m_process_planes.begin(), m_process_planes.end(), iplane) ==
+              m_process_planes.end()) {
+            continue;
+          }
+
           const Pimpos* pimpos = plane->pimpos();
           auto& wires = plane->wires();
 

--- a/larwirecell/Components/DepoSetSimChannelSink.h
+++ b/larwirecell/Components/DepoSetSimChannelSink.h
@@ -57,6 +57,8 @@ namespace wcls {
     double m_g4_ref_time;
     bool m_use_energy;
     bool m_use_extra_sigma; // extra smearing from signal processing
+    std::vector<int> m_process_planes {0,1,2};
+
   };
 }
 

--- a/larwirecell/Components/DepoSetSimChannelSink.h
+++ b/larwirecell/Components/DepoSetSimChannelSink.h
@@ -57,8 +57,7 @@ namespace wcls {
     double m_g4_ref_time;
     bool m_use_energy;
     bool m_use_extra_sigma; // extra smearing from signal processing
-    std::vector<int> m_process_planes {0,1,2};
-
+    std::vector<int> m_process_planes{0, 1, 2};
   };
 }
 

--- a/larwirecell/Components/SimChannelSink.cxx
+++ b/larwirecell/Components/SimChannelSink.cxx
@@ -105,15 +105,14 @@ void SimChannelSink::configure(const WireCell::Configuration& cfg)
   m_use_energy = get(cfg, "use_energy", false);
   m_use_extra_sigma = get(cfg, "use_extra_sigma", false);
 
-  m_process_planes = {0,1,2};
-  
+  m_process_planes = {0, 1, 2};
+
   if (cfg.isMember("process_planes")) {
     m_process_planes.clear();
     for (auto jplane : cfg["process_planes"]) {
       m_process_planes.push_back(jplane.asInt());
     }
   }
-  
 }
 
 void SimChannelSink::produces(art::ProducesCollector& collector)
@@ -154,12 +153,12 @@ void SimChannelSink::save_as_simchannel(const WireCell::IDepo::pointer& depo)
           // plane++;
           int iplane = plane->planeid().index();
           if (iplane < 0) continue;
-	  
-	  if (std::find(m_process_planes.begin(),  m_process_planes.end(), iplane) == m_process_planes.end()) {   	      
-	    continue;
-	  }
 
-	  
+          if (std::find(m_process_planes.begin(), m_process_planes.end(), iplane) ==
+              m_process_planes.end()) {
+            continue;
+          }
+
           const Pimpos* pimpos = plane->pimpos();
           auto& wires = plane->wires();
 

--- a/larwirecell/Components/SimChannelSink.cxx
+++ b/larwirecell/Components/SimChannelSink.cxx
@@ -42,6 +42,8 @@ WireCell::Configuration SimChannelSink::default_configuration() const
   cfg["g4_ref_time"] = -4050 * units::us; // uboone: -4050us, pdsp: -250us
   cfg["use_energy"] = false;
   cfg["use_extra_sigma"] = false;
+  cfg["process_planes"] = Json::arrayValue;
+
   return cfg;
 }
 
@@ -102,6 +104,16 @@ void SimChannelSink::configure(const WireCell::Configuration& cfg)
   m_g4_ref_time = get(cfg, "g4_ref_time", -4050 * units::us);
   m_use_energy = get(cfg, "use_energy", false);
   m_use_extra_sigma = get(cfg, "use_extra_sigma", false);
+
+  m_process_planes = {0,1,2};
+  
+  if (cfg.isMember("process_planes")) {
+    m_process_planes.clear();
+    for (auto jplane : cfg["process_planes"]) {
+      m_process_planes.push_back(jplane.asInt());
+    }
+  }
+  
 }
 
 void SimChannelSink::produces(art::ProducesCollector& collector)
@@ -142,6 +154,12 @@ void SimChannelSink::save_as_simchannel(const WireCell::IDepo::pointer& depo)
           // plane++;
           int iplane = plane->planeid().index();
           if (iplane < 0) continue;
+	  
+	  if (std::find(m_process_planes.begin(),  m_process_planes.end(), iplane) == m_process_planes.end()) {   	      
+	    continue;
+	  }
+
+	  
           const Pimpos* pimpos = plane->pimpos();
           auto& wires = plane->wires();
 

--- a/larwirecell/Components/SimChannelSink.h
+++ b/larwirecell/Components/SimChannelSink.h
@@ -65,7 +65,7 @@ namespace wcls {
     double m_g4_ref_time;
     bool m_use_energy;
     bool m_use_extra_sigma; // extra smearing from signal processing
-    std::vector<int> m_process_planes {0,1,2};
+    std::vector<int> m_process_planes{0, 1, 2};
 
     // double Pi = 3.141592653589;
     // WireCell::Pimpos *uboone_u;

--- a/larwirecell/Components/SimChannelSink.h
+++ b/larwirecell/Components/SimChannelSink.h
@@ -65,6 +65,7 @@ namespace wcls {
     double m_g4_ref_time;
     bool m_use_energy;
     bool m_use_extra_sigma; // extra smearing from signal processing
+    std::vector<int> m_process_planes {0,1,2};
 
     // double Pi = 3.141592653589;
     // WireCell::Pimpos *uboone_u;


### PR DESCRIPTION
This pull request enables the creation of SimChannels for a DepoSet that might only be tied to a single plane. If a specific set of Depos only fall onto one plane these changes enable the creation of SimChannels only for that plane. 

This will result in a large number of SimChannel collections (which was already the case) a future PR could address this by adding in a merging of these collections. 