### PR TITLE
Update Needed For WireCellToolkit to Create SimChannels Per Plane

### DIFF
--- a/larwirecell/Components/DepoFluxWriter.cxx
+++ b/larwirecell/Components/DepoFluxWriter.cxx
@@ -65,7 +65,7 @@ WireCell::Configuration DepoFluxWriter::default_configuration() const
 
   // Provide file name into which validation text is dumped.
   cfg["debug_file"] = m_debug_file;
-  
+
   cfg["process_planes"] = Json::arrayValue;
 
   return cfg;
@@ -130,10 +130,10 @@ void DepoFluxWriter::configure(const WireCell::Configuration& cfg)
   m_process_planes = {0, 1, 2};
 
   if (cfg.isMember("process_planes")) {
-      m_process_planes.clear();
-      for (auto jplane : cfg["process_planes"]) {
-	  m_process_planes.push_back(jplane.asInt());
-      }
+    m_process_planes.clear();
+    for (auto jplane : cfg["process_planes"]) {
+      m_process_planes.push_back(jplane.asInt());
+    }
   }
 
   // Last, per-plane, arbitrary time offsets in terms of ticks.
@@ -252,8 +252,8 @@ void DepoFluxWriter::visit(art::Event& event)
       if (iplane < 0) continue;
 
       if (std::find(m_process_planes.begin(), m_process_planes.end(), iplane) ==
-	  m_process_planes.end()) {
-	  continue;
+          m_process_planes.end()) {
+        continue;
       }
 
       const Pimpos* pimpos = plane->pimpos();

--- a/larwirecell/Components/DepoFluxWriter.h
+++ b/larwirecell/Components/DepoFluxWriter.h
@@ -93,10 +93,10 @@ namespace wcls {
 
     std::string m_debug_file{""};
 
-     // process_planes - This constrains the creation of SimChannels
-     // only to the planes that are relevant, this is important if 
-     // one is using a DepoSetFilter 
-     std::vector<int> m_process_planes{0,1,2};
+    // process_planes - This constrains the creation of SimChannels
+    // only to the planes that are relevant, this is important if
+    // one is using a DepoSetFilter
+    std::vector<int> m_process_planes{0, 1, 2};
 
     // A queue of depos from WCT side
     std::vector<WireCell::IDepo::pointer> m_depos;

--- a/larwirecell/Components/DepoFluxWriter.h
+++ b/larwirecell/Components/DepoFluxWriter.h
@@ -93,6 +93,11 @@ namespace wcls {
 
     std::string m_debug_file{""};
 
+     // process_planes - This constrains the creation of SimChannels
+     // only to the planes that are relevant, this is important if 
+     // one is using a DepoSetFilter 
+     std::vector<int> m_process_planes{0,1,2};
+
     // A queue of depos from WCT side
     std::vector<WireCell::IDepo::pointer> m_depos;
 


### PR DESCRIPTION
This PR adds the capability for the wire-cell-toolkit to produce SimChannels on a plane-by-plane basis in case there is a different behavior once the DepoSet has been filtered. 

The default behavior shouldn't have changed since the default compares all the planes. 