### PR TITLE
PR49 fix

### DIFF
--- a/larwirecell/Components/CookedFrameSource.cxx
+++ b/larwirecell/Components/CookedFrameSource.cxx
@@ -7,9 +7,9 @@
 
 #include "TTimeStamp.h"
 
+#include "WireCellAux/FrameTools.h"
 #include "WireCellAux/SimpleFrame.h"
 #include "WireCellAux/SimpleTrace.h"
-#include "WireCellAux/FrameTools.h"
 #include "WireCellUtil/NamedFactory.h"
 #include "WireCellUtil/Waveform.h"
 

--- a/larwirecell/Components/CookedFrameSource.cxx
+++ b/larwirecell/Components/CookedFrameSource.cxx
@@ -42,24 +42,38 @@ void CookedFrameSource::configure(const WireCell::Configuration& cfg)
   m_scale = get(cfg, "scale", m_scale);
   m_tick = get(cfg, "tick", m_tick);
   m_nticks = get(cfg, "nticks", m_nticks);
-
-  for (auto recobwire_tag : cfg["recobwire_tags"]) {
-    m_recobwire_tags.push_back(recobwire_tag.asString());
-  }
   for (auto jtag : cfg["frame_tags"]) {
     m_frame_tags.push_back(jtag.asString());
-  }
-  for (auto jtag : cfg["trace_tags"]) {
-    m_trace_tags.push_back(jtag.asString());
-  }
-  for (auto summary_tag : cfg["summary_tags"]) {
-    m_summary_tags.push_back(summary_tag.asString());
   }
   for (auto mask_tag : cfg["input_mask_tags"]) {
     m_input_mask_tags.push_back(mask_tag.asString());
   }
   for (auto mask_tag : cfg["output_mask_tags"]) {
     m_output_mask_tags.push_back(mask_tag.asString());
+  }
+  if (m_input_mask_tags.size() != m_output_mask_tags.size()) {
+    raise<ValueError>("m_input_mask_tags.size %d != m_output_mask_tags.size %d",
+                      m_input_mask_tags.size(),
+                      m_output_mask_tags.size());
+  }
+
+  const std::string art_tag = cfg["art_tag"].asString();
+  if (!art_tag.empty()) {
+    l->warn("CookedFrameSource: art_tag is set, running in back-compat mode");
+    m_recobwire_tags.push_back(art_tag);
+    m_trace_tags.push_back("");
+    m_summary_tags.push_back("");
+    return;
+  }
+
+  for (auto recobwire_tag : cfg["recobwire_tags"]) {
+    m_recobwire_tags.push_back(recobwire_tag.asString());
+  }
+  for (auto jtag : cfg["trace_tags"]) {
+    m_trace_tags.push_back(jtag.asString());
+  }
+  for (auto summary_tag : cfg["summary_tags"]) {
+    m_summary_tags.push_back(summary_tag.asString());
   }
   if (m_recobwire_tags.size() != m_summary_tags.size()) {
     raise<ValueError>("m_recobwire_tags.size %d != m_summary_tags.size %d",
@@ -70,11 +84,6 @@ void CookedFrameSource::configure(const WireCell::Configuration& cfg)
     raise<ValueError>("m_recobwire_tags.size %d != m_trace_tags.size %d",
                       m_recobwire_tags.size(),
                       m_trace_tags.size());
-  }
-  if (m_input_mask_tags.size() != m_output_mask_tags.size()) {
-    raise<ValueError>("m_input_mask_tags.size %d != m_output_mask_tags.size %d",
-                      m_input_mask_tags.size(),
-                      m_output_mask_tags.size());
   }
 }
 

--- a/larwirecell/Components/CookedFrameSource.h
+++ b/larwirecell/Components/CookedFrameSource.h
@@ -41,7 +41,7 @@ namespace wcls {
     std::deque<WireCell::IFrame::pointer> m_frames;
     double m_tick;
     int m_nticks;
-    double m_scale{50}; // scale up input recob::Wire by this factor
+    double m_scale{1.}; // scale up input recob::Wire by this factor
     std::vector<std::string> m_frame_tags;
     std::vector<std::string> m_recobwire_tags;
     std::vector<std::string> m_trace_tags;


### PR DESCRIPTION
Thanks to @tomjunk and Andrew Olivier for spotting this bug! Details in https://github.com/LArSoft/larwirecell/issues/51

The fix is in two parts.
- minor bug: `scale` needs to be set to `1.0` for some cases. This PR fixes a bug when not setting it.
- main bug: The configurations needs to be updated together with the new `CookedFrameSource` as @tomjunk suggested. This is fixed in https://github.com/DUNE/dunereco/pull/126
  - as suggested by @brettviren, a back-compat mode was added in [d26b2da](https://github.com/LArSoft/larwirecell/pull/53/commits/d26b2da1f8d5f236749b1f2f9b6ca81086028e1e)
- [ ] Next: need to check whether other non-DUNE experiments also used the `CookedFrameSource`, currently find none by searching the `wire-cell-toolkit` repo.

Some notes:
[larwirecell-pr49.pdf](https://github.com/user-attachments/files/18500921/larwirecell-pr49.pdf)
