### PR TITLE
DepoFluxWriter bugfix: check empty config, not existing

### DIFF
--- a/larwirecell/Components/DepoFluxWriter.cxx
+++ b/larwirecell/Components/DepoFluxWriter.cxx
@@ -128,8 +128,7 @@ void DepoFluxWriter::configure(const WireCell::Configuration& cfg)
   }
 
   m_process_planes = {0, 1, 2};
-
-  if (cfg.isMember("process_planes")) {
+  if (!cfg["process_planes"].empty()) {
     m_process_planes.clear();
     for (auto jplane : cfg["process_planes"]) {
       m_process_planes.push_back(jplane.asInt());

--- a/larwirecell/Components/DepoFluxWriter.cxx
+++ b/larwirecell/Components/DepoFluxWriter.cxx
@@ -66,8 +66,6 @@ WireCell::Configuration DepoFluxWriter::default_configuration() const
   // Provide file name into which validation text is dumped.
   cfg["debug_file"] = m_debug_file;
 
-  cfg["process_planes"] = Json::arrayValue;
-
   return cfg;
 }
 
@@ -128,7 +126,7 @@ void DepoFluxWriter::configure(const WireCell::Configuration& cfg)
   }
 
   m_process_planes = {0, 1, 2};
-  if (!cfg["process_planes"].empty()) {
+  if (cfg["process_planes"].isArray()) {
     m_process_planes.clear();
     for (auto jplane : cfg["process_planes"]) {
       m_process_planes.push_back(jplane.asInt());


### PR DESCRIPTION
Instead of checking that `"process_planes"` exists in the cfg (it always will, being declared in line 69), checks if it's empty before clearing `m_process_planes`. This bug was leading to SimChannels always being empty since `m_process_planes` was also empty. 

@jzennamo feel free to add any comments you might have! 