### PR TITLE
Force consistent behavior when truncating nan's in FrameSaver.

### DIFF
--- a/larwirecell/Components/FrameSaver.cxx
+++ b/larwirecell/Components/FrameSaver.cxx
@@ -315,7 +315,10 @@ void FrameSaver::save_as_raw(art::Event& event)
       }
       raw::RawDigit::ADCvector_t adcv(nticks);
       for (size_t ind = 0; ind < ncharge; ++ind) {
-        adcv[tbin + ind] = scale * charge[ind]; // scale + truncate/redigitize
+        if(finite(charge[ind]))
+          adcv[tbin + ind] = scale * charge[ind]; // scale + truncate/redigitize
+        else
+          adcv[tbin + ind] = 0;
       }
       out->emplace_back(raw::RawDigit(chid, nticks, adcv, raw::kNone));
       if (m_pedestal_mean.asString() == "native") {

--- a/larwirecell/Components/FrameSaver.cxx
+++ b/larwirecell/Components/FrameSaver.cxx
@@ -315,7 +315,7 @@ void FrameSaver::save_as_raw(art::Event& event)
       }
       raw::RawDigit::ADCvector_t adcv(nticks);
       for (size_t ind = 0; ind < ncharge; ++ind) {
-        if(finite(charge[ind]))
+        if (finite(charge[ind]))
           adcv[tbin + ind] = scale * charge[ind]; // scale + truncate/redigitize
         else
           adcv[tbin + ind] = 0;


### PR DESCRIPTION
Converting nan's and inf's to integer types is undefined in c++.  Experimentally, gcc is converting nan's to 0 and clang is converting nan's to the largest negative integer, at least in this code instance, in the optimized build.  Clang's treatment is triggering a crash in follow-on wirecell toolkit code.  This PR is forcing treatment of nan's to be consistent accross compilers and build types, and to do what gcc is already doing by default.  Therefore, this PR is nobreaking for gcc.
