### PR TITLE
Add TrackIDPIDMap2h5 and extend Labelling2D with energy fraction and …

### DIFF
--- a/larwirecell/aiml/CMakeLists.txt
+++ b/larwirecell/aiml/CMakeLists.txt
@@ -1,15 +1,15 @@
-
-
 cet_make_library(LIBRARY_NAME WireCellAIML
     SOURCE
         Labelling2D.cxx
         Truth2h5.cxx
+        TrackIDPIDMap2h5.cxx
     LIBRARIES
     PUBLIC
         ${HDF5_LIBRARIES}
         WireCell::Util
         WireCell::Aux
         WireCell::Iface
+        larwirecell::IArtEventVisitor
         lardataobj::Simulation
         nusimdata::SimulationBase
         art::Framework_Core

--- a/larwirecell/aiml/Labelling2D.cxx
+++ b/larwirecell/aiml/Labelling2D.cxx
@@ -228,26 +228,28 @@ bool AIML::Labelling2D::operator()(const input_pointer& in, output_pointer& out)
 
     // Rebinned traces
     std::size_t rebinned_size = (reco_charge.size() + m_rebin_time_tick - 1) / m_rebin_time_tick;
-    SimpleTrace* trackid_1st_trace   = new SimpleTrace(chid, trace->tbin(), rebinned_size);
-    SimpleTrace* trackid_2nd_trace   = new SimpleTrace(chid, trace->tbin(), rebinned_size);
-    SimpleTrace* pid_1st_trace       = new SimpleTrace(chid, trace->tbin(), rebinned_size);
-    SimpleTrace* pid_2nd_trace       = new SimpleTrace(chid, trace->tbin(), rebinned_size);
+    SimpleTrace* trackid_1st_trace = new SimpleTrace(chid, trace->tbin(), rebinned_size);
+    SimpleTrace* trackid_2nd_trace = new SimpleTrace(chid, trace->tbin(), rebinned_size);
+    SimpleTrace* pid_1st_trace = new SimpleTrace(chid, trace->tbin(), rebinned_size);
+    SimpleTrace* pid_2nd_trace = new SimpleTrace(chid, trace->tbin(), rebinned_size);
     SimpleTrace* energyfrac_1st_trace = new SimpleTrace(chid, trace->tbin(), rebinned_size);
     SimpleTrace* energyfrac_2nd_trace = new SimpleTrace(chid, trace->tbin(), rebinned_size);
     SimpleTrace* total_numelectrons_trace = new SimpleTrace(chid, trace->tbin(), rebinned_size);
 
-    auto& trackid_1st_values    = trackid_1st_trace->charge();
-    auto& trackid_2nd_values    = trackid_2nd_trace->charge();
-    auto& pid_1st_values        = pid_1st_trace->charge();
-    auto& pid_2nd_values        = pid_2nd_trace->charge();
+    auto& trackid_1st_values = trackid_1st_trace->charge();
+    auto& trackid_2nd_values = trackid_2nd_trace->charge();
+    auto& pid_1st_values = pid_1st_trace->charge();
+    auto& pid_2nd_values = pid_2nd_trace->charge();
     auto& energyfrac_1st_values = energyfrac_1st_trace->charge();
     auto& energyfrac_2nd_values = energyfrac_2nd_trace->charge();
     auto& total_numelectrons_values = total_numelectrons_trace->charge();
 
-    std::fill(trackid_1st_values.begin(),    trackid_1st_values.end(),    static_cast<float>(m_default_label));
-    std::fill(trackid_2nd_values.begin(),    trackid_2nd_values.end(),    static_cast<float>(m_default_label));
-    std::fill(pid_1st_values.begin(),        pid_1st_values.end(),        0.0f);
-    std::fill(pid_2nd_values.begin(),        pid_2nd_values.end(),        0.0f);
+    std::fill(
+      trackid_1st_values.begin(), trackid_1st_values.end(), static_cast<float>(m_default_label));
+    std::fill(
+      trackid_2nd_values.begin(), trackid_2nd_values.end(), static_cast<float>(m_default_label));
+    std::fill(pid_1st_values.begin(), pid_1st_values.end(), 0.0f);
+    std::fill(pid_2nd_values.begin(), pid_2nd_values.end(), 0.0f);
     std::fill(energyfrac_1st_values.begin(), energyfrac_1st_values.end(), 0.0f);
     std::fill(energyfrac_2nd_values.begin(), energyfrac_2nd_values.end(), 0.0f);
     std::fill(total_numelectrons_values.begin(), total_numelectrons_values.end(), 0.0f);
@@ -295,12 +297,12 @@ bool AIML::Labelling2D::operator()(const input_pointer& in, output_pointer& out)
 
         auto [efrac_1st, efrac_2nd, total_ne] = select_top2_energyfracs(*sc, tdc_begin, tdc_end);
 
-        trackid_1st_values[ibin]        = static_cast<float>(track_id_1st);
-        trackid_2nd_values[ibin]        = static_cast<float>(track_id_2nd);
-        pid_1st_values[ibin]            = static_cast<float>(pid_1st);
-        pid_2nd_values[ibin]            = static_cast<float>(pid_2nd);
-        energyfrac_1st_values[ibin]     = efrac_1st;
-        energyfrac_2nd_values[ibin]     = efrac_2nd;
+        trackid_1st_values[ibin] = static_cast<float>(track_id_1st);
+        trackid_2nd_values[ibin] = static_cast<float>(track_id_2nd);
+        pid_1st_values[ibin] = static_cast<float>(pid_1st);
+        pid_2nd_values[ibin] = static_cast<float>(pid_2nd);
+        energyfrac_1st_values[ibin] = efrac_1st;
+        energyfrac_2nd_values[ibin] = efrac_2nd;
         total_numelectrons_values[ibin] = total_ne;
       }
     }
@@ -320,11 +322,14 @@ bool AIML::Labelling2D::operator()(const input_pointer& in, output_pointer& out)
     traces_buffer->push_back(ITrace::pointer(pid_1st_trace));
     pid_2nd_indices.push_back(static_cast<IFrame::trace_list_t::value_type>(traces_buffer->size()));
     traces_buffer->push_back(ITrace::pointer(pid_2nd_trace));
-    energyfrac_1st_indices.push_back(static_cast<IFrame::trace_list_t::value_type>(traces_buffer->size()));
+    energyfrac_1st_indices.push_back(
+      static_cast<IFrame::trace_list_t::value_type>(traces_buffer->size()));
     traces_buffer->push_back(ITrace::pointer(energyfrac_1st_trace));
-    energyfrac_2nd_indices.push_back(static_cast<IFrame::trace_list_t::value_type>(traces_buffer->size()));
+    energyfrac_2nd_indices.push_back(
+      static_cast<IFrame::trace_list_t::value_type>(traces_buffer->size()));
     traces_buffer->push_back(ITrace::pointer(energyfrac_2nd_trace));
-    total_numelectrons_indices.push_back(static_cast<IFrame::trace_list_t::value_type>(traces_buffer->size()));
+    total_numelectrons_indices.push_back(
+      static_cast<IFrame::trace_list_t::value_type>(traces_buffer->size()));
     traces_buffer->push_back(ITrace::pointer(total_numelectrons_trace));
   }
 
@@ -561,9 +566,10 @@ int AIML::Labelling2D::pid_from_track(int track_id) const
   return it->second;
 }
 
-std::tuple<float, float, float> AIML::Labelling2D::select_top2_energyfracs(const sim::SimChannel& sc,
-                                                                            int tdc_begin,
-                                                                            int tdc_end) const
+std::tuple<float, float, float> AIML::Labelling2D::select_top2_energyfracs(
+  const sim::SimChannel& sc,
+  int tdc_begin,
+  int tdc_end) const
 {
   // Rank tracks by numElectrons (same ordering as select_top2_track_ids),
   // then compute charge fraction as track_numElectrons / total_numElectrons.

--- a/larwirecell/aiml/Labelling2D.cxx
+++ b/larwirecell/aiml/Labelling2D.cxx
@@ -14,6 +14,7 @@
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include <algorithm>
 #include <cmath>
+#include <tuple>
 
 WIRECELL_FACTORY(Labelling2D,
                  WireCell::AIML::Labelling2D,
@@ -44,6 +45,9 @@ AIML::Labelling2D::Labelling2D()
   , m_output_trace_tag_trackid_2nd("trackid_2nd")
   , m_output_trace_tag_pid_1st("pid_1st")
   , m_output_trace_tag_pid_2nd("pid_2nd")
+  , m_output_trace_tag_energyfrac_1st("energyfrac_1st")
+  , m_output_trace_tag_energyfrac_2nd("energyfrac_2nd")
+  , m_output_trace_tag_total_numelectrons("total_numelectrons")
   , m_output_trace_tag_rebinned_reco("rebinned_reco")
   , m_default_label(0)
   , m_tdc_offset(0)
@@ -67,6 +71,9 @@ Configuration AIML::Labelling2D::default_configuration() const
   cfg["output_trace_tag_trackid_2nd"] = m_output_trace_tag_trackid_2nd;
   cfg["output_trace_tag_pid_1st"] = m_output_trace_tag_pid_1st;
   cfg["output_trace_tag_pid_2nd"] = m_output_trace_tag_pid_2nd;
+  cfg["output_trace_tag_energyfrac_1st"] = m_output_trace_tag_energyfrac_1st;
+  cfg["output_trace_tag_energyfrac_2nd"] = m_output_trace_tag_energyfrac_2nd;
+  cfg["output_trace_tag_total_numelectrons"] = m_output_trace_tag_total_numelectrons;
   cfg["output_trace_tag_rebinned_reco"] = m_output_trace_tag_rebinned_reco;
   cfg["default_label"] = m_default_label;
   cfg["tdc_offset"] = m_tdc_offset;
@@ -95,6 +102,12 @@ void AIML::Labelling2D::configure(const Configuration& cfg)
     get(cfg, "output_trace_tag_trackid_2nd", m_output_trace_tag_trackid_2nd);
   m_output_trace_tag_pid_1st = get(cfg, "output_trace_tag_pid_1st", m_output_trace_tag_pid_1st);
   m_output_trace_tag_pid_2nd = get(cfg, "output_trace_tag_pid_2nd", m_output_trace_tag_pid_2nd);
+  m_output_trace_tag_energyfrac_1st =
+    get(cfg, "output_trace_tag_energyfrac_1st", m_output_trace_tag_energyfrac_1st);
+  m_output_trace_tag_energyfrac_2nd =
+    get(cfg, "output_trace_tag_energyfrac_2nd", m_output_trace_tag_energyfrac_2nd);
+  m_output_trace_tag_total_numelectrons =
+    get(cfg, "output_trace_tag_total_numelectrons", m_output_trace_tag_total_numelectrons);
   m_output_trace_tag_rebinned_reco =
     get(cfg, "output_trace_tag_rebinned_reco", m_output_trace_tag_rebinned_reco);
   const int configured_default = get(cfg, "default_label", m_default_label);
@@ -175,6 +188,9 @@ bool AIML::Labelling2D::operator()(const input_pointer& in, output_pointer& out)
   IFrame::trace_list_t trackid_2nd_indices;
   IFrame::trace_list_t pid_1st_indices;
   IFrame::trace_list_t pid_2nd_indices;
+  IFrame::trace_list_t energyfrac_1st_indices;
+  IFrame::trace_list_t energyfrac_2nd_indices;
+  IFrame::trace_list_t total_numelectrons_indices;
 
   trackid_indices.reserve(reco_traces.size());
   pid_indices.reserve(reco_traces.size());
@@ -182,6 +198,9 @@ bool AIML::Labelling2D::operator()(const input_pointer& in, output_pointer& out)
   trackid_2nd_indices.reserve(reco_traces.size());
   pid_1st_indices.reserve(reco_traces.size());
   pid_2nd_indices.reserve(reco_traces.size());
+  energyfrac_1st_indices.reserve(reco_traces.size());
+  energyfrac_2nd_indices.reserve(reco_traces.size());
+  total_numelectrons_indices.reserve(reco_traces.size());
 
   for (auto const& trace : reco_traces) {
     if (!trace) { continue; }
@@ -209,22 +228,29 @@ bool AIML::Labelling2D::operator()(const input_pointer& in, output_pointer& out)
 
     // Rebinned traces
     std::size_t rebinned_size = (reco_charge.size() + m_rebin_time_tick - 1) / m_rebin_time_tick;
-    SimpleTrace* trackid_1st_trace = new SimpleTrace(chid, trace->tbin(), rebinned_size);
-    SimpleTrace* trackid_2nd_trace = new SimpleTrace(chid, trace->tbin(), rebinned_size);
-    SimpleTrace* pid_1st_trace = new SimpleTrace(chid, trace->tbin(), rebinned_size);
-    SimpleTrace* pid_2nd_trace = new SimpleTrace(chid, trace->tbin(), rebinned_size);
+    SimpleTrace* trackid_1st_trace   = new SimpleTrace(chid, trace->tbin(), rebinned_size);
+    SimpleTrace* trackid_2nd_trace   = new SimpleTrace(chid, trace->tbin(), rebinned_size);
+    SimpleTrace* pid_1st_trace       = new SimpleTrace(chid, trace->tbin(), rebinned_size);
+    SimpleTrace* pid_2nd_trace       = new SimpleTrace(chid, trace->tbin(), rebinned_size);
+    SimpleTrace* energyfrac_1st_trace = new SimpleTrace(chid, trace->tbin(), rebinned_size);
+    SimpleTrace* energyfrac_2nd_trace = new SimpleTrace(chid, trace->tbin(), rebinned_size);
+    SimpleTrace* total_numelectrons_trace = new SimpleTrace(chid, trace->tbin(), rebinned_size);
 
-    auto& trackid_1st_values = trackid_1st_trace->charge();
-    auto& trackid_2nd_values = trackid_2nd_trace->charge();
-    auto& pid_1st_values = pid_1st_trace->charge();
-    auto& pid_2nd_values = pid_2nd_trace->charge();
+    auto& trackid_1st_values    = trackid_1st_trace->charge();
+    auto& trackid_2nd_values    = trackid_2nd_trace->charge();
+    auto& pid_1st_values        = pid_1st_trace->charge();
+    auto& pid_2nd_values        = pid_2nd_trace->charge();
+    auto& energyfrac_1st_values = energyfrac_1st_trace->charge();
+    auto& energyfrac_2nd_values = energyfrac_2nd_trace->charge();
+    auto& total_numelectrons_values = total_numelectrons_trace->charge();
 
-    std::fill(
-      trackid_1st_values.begin(), trackid_1st_values.end(), static_cast<float>(m_default_label));
-    std::fill(
-      trackid_2nd_values.begin(), trackid_2nd_values.end(), static_cast<float>(m_default_label));
-    std::fill(pid_1st_values.begin(), pid_1st_values.end(), 0.0f);
-    std::fill(pid_2nd_values.begin(), pid_2nd_values.end(), 0.0f);
+    std::fill(trackid_1st_values.begin(),    trackid_1st_values.end(),    static_cast<float>(m_default_label));
+    std::fill(trackid_2nd_values.begin(),    trackid_2nd_values.end(),    static_cast<float>(m_default_label));
+    std::fill(pid_1st_values.begin(),        pid_1st_values.end(),        0.0f);
+    std::fill(pid_2nd_values.begin(),        pid_2nd_values.end(),        0.0f);
+    std::fill(energyfrac_1st_values.begin(), energyfrac_1st_values.end(), 0.0f);
+    std::fill(energyfrac_2nd_values.begin(), energyfrac_2nd_values.end(), 0.0f);
+    std::fill(total_numelectrons_values.begin(), total_numelectrons_values.end(), 0.0f);
 
     if (sc) {
       const int base_tbin = trace->tbin();
@@ -267,10 +293,15 @@ bool AIML::Labelling2D::operator()(const input_pointer& in, output_pointer& out)
         int pid_1st = top2_pids.first;
         int pid_2nd = top2_pids.second;
 
-        trackid_1st_values[ibin] = static_cast<float>(track_id_1st);
-        trackid_2nd_values[ibin] = static_cast<float>(track_id_2nd);
-        pid_1st_values[ibin] = static_cast<float>(pid_1st);
-        pid_2nd_values[ibin] = static_cast<float>(pid_2nd);
+        auto [efrac_1st, efrac_2nd, total_ne] = select_top2_energyfracs(*sc, tdc_begin, tdc_end);
+
+        trackid_1st_values[ibin]        = static_cast<float>(track_id_1st);
+        trackid_2nd_values[ibin]        = static_cast<float>(track_id_2nd);
+        pid_1st_values[ibin]            = static_cast<float>(pid_1st);
+        pid_2nd_values[ibin]            = static_cast<float>(pid_2nd);
+        energyfrac_1st_values[ibin]     = efrac_1st;
+        energyfrac_2nd_values[ibin]     = efrac_2nd;
+        total_numelectrons_values[ibin] = total_ne;
       }
     }
 
@@ -289,6 +320,12 @@ bool AIML::Labelling2D::operator()(const input_pointer& in, output_pointer& out)
     traces_buffer->push_back(ITrace::pointer(pid_1st_trace));
     pid_2nd_indices.push_back(static_cast<IFrame::trace_list_t::value_type>(traces_buffer->size()));
     traces_buffer->push_back(ITrace::pointer(pid_2nd_trace));
+    energyfrac_1st_indices.push_back(static_cast<IFrame::trace_list_t::value_type>(traces_buffer->size()));
+    traces_buffer->push_back(ITrace::pointer(energyfrac_1st_trace));
+    energyfrac_2nd_indices.push_back(static_cast<IFrame::trace_list_t::value_type>(traces_buffer->size()));
+    traces_buffer->push_back(ITrace::pointer(energyfrac_2nd_trace));
+    total_numelectrons_indices.push_back(static_cast<IFrame::trace_list_t::value_type>(traces_buffer->size()));
+    traces_buffer->push_back(ITrace::pointer(total_numelectrons_trace));
   }
 
   // Create rebinned reco traces
@@ -342,6 +379,15 @@ bool AIML::Labelling2D::operator()(const input_pointer& in, output_pointer& out)
   }
   if (!m_output_trace_tag_pid_2nd.empty()) {
     sframe->tag_traces(m_output_trace_tag_pid_2nd, pid_2nd_indices);
+  }
+  if (!m_output_trace_tag_energyfrac_1st.empty()) {
+    sframe->tag_traces(m_output_trace_tag_energyfrac_1st, energyfrac_1st_indices);
+  }
+  if (!m_output_trace_tag_energyfrac_2nd.empty()) {
+    sframe->tag_traces(m_output_trace_tag_energyfrac_2nd, energyfrac_2nd_indices);
+  }
+  if (!m_output_trace_tag_total_numelectrons.empty()) {
+    sframe->tag_traces(m_output_trace_tag_total_numelectrons, total_numelectrons_indices);
   }
 
   // Tag the rebinned reco traces
@@ -513,6 +559,30 @@ int AIML::Labelling2D::pid_from_track(int track_id) const
   auto it = m_trackid_to_pid.find(track_id);
   if (it == m_trackid_to_pid.end()) { return 0; }
   return it->second;
+}
+
+std::tuple<float, float, float> AIML::Labelling2D::select_top2_energyfracs(const sim::SimChannel& sc,
+                                                                            int tdc_begin,
+                                                                            int tdc_end) const
+{
+  // Rank tracks by numElectrons (same ordering as select_top2_track_ids),
+  // then compute charge fraction as track_numElectrons / total_numElectrons.
+  auto track_charges = extract_track_charges(sc, tdc_begin, tdc_end);
+  if (track_charges.empty()) { return {0.0f, 0.0f, 0.0f}; }
+
+  double total_charge = 0.0;
+  for (auto const& tc : track_charges) {
+    total_charge += tc.second;
+  }
+
+  if (total_charge <= 0.0) { return {0.0f, 0.0f, 0.0f}; }
+
+  float efrac_1st = static_cast<float>(track_charges[0].second / total_charge);
+  float efrac_2nd = 0.0f;
+  if (track_charges.size() > 1) {
+    efrac_2nd = static_cast<float>(track_charges[1].second / total_charge);
+  }
+  return {efrac_1st, efrac_2nd, static_cast<float>(total_charge)};
 }
 
 void AIML::Labelling2D::clear_cache()

--- a/larwirecell/aiml/Labelling2D.h
+++ b/larwirecell/aiml/Labelling2D.h
@@ -10,6 +10,7 @@
 
 #include <memory>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 
@@ -54,6 +55,10 @@ namespace WireCell::AIML {
     std::pair<int, int> select_top2_pids(const sim::SimChannel& sc,
                                          int tdc_begin,
                                          int tdc_end) const;
+    // Returns {energyfrac_1st, energyfrac_2nd, total_numElectrons} for the top-2 tracks by charge
+    std::tuple<float, float, float> select_top2_energyfracs(const sim::SimChannel& sc,
+                                                             int tdc_begin,
+                                                             int tdc_end) const;
 
     WireCell::IAnodePlane::pointer m_anode;
     std::string m_anode_tn;
@@ -64,6 +69,9 @@ namespace WireCell::AIML {
     std::string m_output_trace_tag_trackid_2nd;
     std::string m_output_trace_tag_pid_1st;
     std::string m_output_trace_tag_pid_2nd;
+    std::string m_output_trace_tag_energyfrac_1st;
+    std::string m_output_trace_tag_energyfrac_2nd;
+    std::string m_output_trace_tag_total_numelectrons;
     std::string m_output_trace_tag_rebinned_reco;
     std::vector<std::string> m_frame_tags;
     std::string m_simchannel_label;

--- a/larwirecell/aiml/Labelling2D.h
+++ b/larwirecell/aiml/Labelling2D.h
@@ -57,8 +57,8 @@ namespace WireCell::AIML {
                                          int tdc_end) const;
     // Returns {energyfrac_1st, energyfrac_2nd, total_numElectrons} for the top-2 tracks by charge
     std::tuple<float, float, float> select_top2_energyfracs(const sim::SimChannel& sc,
-                                                             int tdc_begin,
-                                                             int tdc_end) const;
+                                                            int tdc_begin,
+                                                            int tdc_end) const;
 
     WireCell::IAnodePlane::pointer m_anode;
     std::string m_anode_tn;

--- a/larwirecell/aiml/TrackIDPIDMap2h5.cxx
+++ b/larwirecell/aiml/TrackIDPIDMap2h5.cxx
@@ -621,10 +621,11 @@ bool AIML::TrackIDPIDMap2h5::keep_mc(int tid) const
 
 bool AIML::TrackIDPIDMap2h5::dump_mc_json_node(int tid, std::ostream& out) const
 {
-  if (m_trackid_to_pid.find(tid) == m_trackid_to_pid.end()) return false;
+  auto it = m_trackid_to_pid.find(tid);
+  if (it == m_trackid_to_pid.end()) return false;
   if (!keep_mc(tid)) return false;
 
-  int pdg = m_trackid_to_pid.at(tid);
+  int pdg = it->second;
 
   // KE in MeV
   int ke_mev = 0;

--- a/larwirecell/aiml/TrackIDPIDMap2h5.cxx
+++ b/larwirecell/aiml/TrackIDPIDMap2h5.cxx
@@ -30,40 +30,40 @@ using namespace WireCell;
 
 // G4 process name → integer code mapping (following CellTree convention)
 const std::map<std::string, int> AIML::TrackIDPIDMap2h5::s_process_map = {
-  {"primary",                  0},
-  {"Decay",                    1},
-  {"eIoni",                    2},
-  {"muIoni",                   3},
-  {"eBrem",                    4},
-  {"compt",                    5},
-  {"phot",                     6},
-  {"conv",                     7},
-  {"hIoni",                    8},
-  {"nCapture",                 9},
-  {"muPairProd",              10},
-  {"CoulombScat",             11},
-  {"muBrems",                 12},
-  {"LowEnConversion",         13},
-  {"annihil",                 14},
-  {"neutronInelastic",        15},
-  {"hadElastic",              16},
-  {"hBertiniCaptureAtRest",   17},
-  {"muMinusCaptureAtRest",    18},
-  {"protonInelastic",         19},
-  {"pi+Inelastic",            20},
-  {"pi-Inelastic",            21},
-  {"PhotonInelastic",         22},
+  {"primary", 0},
+  {"Decay", 1},
+  {"eIoni", 2},
+  {"muIoni", 3},
+  {"eBrem", 4},
+  {"compt", 5},
+  {"phot", 6},
+  {"conv", 7},
+  {"hIoni", 8},
+  {"nCapture", 9},
+  {"muPairProd", 10},
+  {"CoulombScat", 11},
+  {"muBrems", 12},
+  {"LowEnConversion", 13},
+  {"annihil", 14},
+  {"neutronInelastic", 15},
+  {"hadElastic", 16},
+  {"hBertiniCaptureAtRest", 17},
+  {"muMinusCaptureAtRest", 18},
+  {"protonInelastic", 19},
+  {"pi+Inelastic", 20},
+  {"pi-Inelastic", 21},
+  {"PhotonInelastic", 22},
   {"CHIPSNuclearCaptureAtRest", 23},
-  {"Transportation",           24},
-  {"kaon+Inelastic",           25},
-  {"kaon-Inelastic",           26},
-  {"kaon0LInelastic",          27},
-  {"ionInelastic",             28},
-  {"Scintillation",            29},
-  {"ionIoni",                  30},
-  {"nKiller",                  31},
-  {"StepLimiter",              32},
-  {"dInelastic",               33},
+  {"Transportation", 24},
+  {"kaon+Inelastic", 25},
+  {"kaon-Inelastic", 26},
+  {"kaon0LInelastic", 27},
+  {"ionInelastic", 28},
+  {"Scintillation", 29},
+  {"ionIoni", 30},
+  {"nKiller", 31},
+  {"StepLimiter", 32},
+  {"dInelastic", 33},
 };
 
 AIML::TrackIDPIDMap2h5::TrackIDPIDMap2h5()
@@ -122,14 +122,13 @@ void AIML::TrackIDPIDMap2h5::visit(art::Event& event)
       for (auto const& particle : *particle_handle) {
         int tid = particle.TrackId();
         if (tid == 0) { continue; }
-        m_trackid_to_pid[tid]      = particle.PdgCode();
+        m_trackid_to_pid[tid] = particle.PdgCode();
         m_trackid_to_motherid[tid] = particle.Mother();
         // Map G4 process name to integer code; -1 for unknown
         auto it = s_process_map.find(particle.Process());
         if (it == s_process_map.end()) {
-            std::cout << "Process not in map: tid=" << tid
-                      << " pdg=" << particle.PdgCode()
-                      << " process=\"" << particle.Process() << "\"\n";
+          std::cout << "Process not in map: tid=" << tid << " pdg=" << particle.PdgCode()
+                    << " process=\"" << particle.Process() << "\"\n";
         }
         m_trackid_to_process[tid] = (it != s_process_map.end()) ? it->second : -1;
         // Start/end positions and momentum from trajectory
@@ -138,11 +137,13 @@ void AIML::TrackIDPIDMap2h5::visit(art::Event& event)
           const TLorentzVector& s4 = particle.Position(0);
           const TLorentzVector& e4 = particle.Position(npts - 1);
           m_trackid_to_start[tid] = {(float)s4.X(), (float)s4.Y(), (float)s4.Z(), (float)s4.T()};
-          m_trackid_to_end[tid]   = {(float)e4.X(), (float)e4.Y(), (float)e4.Z(), (float)e4.T()};
+          m_trackid_to_end[tid] = {(float)e4.X(), (float)e4.Y(), (float)e4.Z(), (float)e4.T()};
           const TLorentzVector& mom0 = particle.Momentum(0);
-          m_trackid_to_startmom[tid] = {(float)mom0.Px(), (float)mom0.Py(), (float)mom0.Pz(), (float)mom0.E()};
+          m_trackid_to_startmom[tid] = {
+            (float)mom0.Px(), (float)mom0.Py(), (float)mom0.Pz(), (float)mom0.E()};
           const TLorentzVector& momN = particle.Momentum(npts - 1);
-          m_trackid_to_endmom[tid] = {(float)momN.Px(), (float)momN.Py(), (float)momN.Pz(), (float)momN.E()};
+          m_trackid_to_endmom[tid] = {
+            (float)momN.Px(), (float)momN.Py(), (float)momN.Pz(), (float)momN.E()};
           // Daughters
           std::vector<int> daughters;
           for (int d = 0; d < particle.NumberDaughters(); ++d) {
@@ -153,19 +154,18 @@ void AIML::TrackIDPIDMap2h5::visit(art::Event& event)
           if (m_save_extended_mcpart) {
             auto eit = s_process_map.find(particle.EndProcess());
             if (eit == s_process_map.end() && !particle.EndProcess().empty()) {
-              std::cout << "EndProcess not in map: tid=" << tid
-                        << " pdg=" << particle.PdgCode()
+              std::cout << "EndProcess not in map: tid=" << tid << " pdg=" << particle.PdgCode()
                         << " endprocess=\"" << particle.EndProcess() << "\"\n";
             }
             m_trackid_to_endprocess[tid] = (eit != s_process_map.end()) ? eit->second : -1;
-            m_trackid_to_status[tid]     = particle.StatusCode();
-            m_trackid_to_mass[tid]       = (float)particle.Mass();
+            m_trackid_to_status[tid] = particle.StatusCode();
+            m_trackid_to_mass[tid] = (float)particle.Mass();
             m_trackid_to_ndaughters[tid] = particle.NumberDaughters();
-            m_trackid_to_ntrajpts[tid]   = (int)npts;
+            m_trackid_to_ntrajpts[tid] = (int)npts;
           }
           // Trajectory points (for JSON visualization)
           if (m_save_mc_json) {
-            std::vector<std::array<float,3>> traj;
+            std::vector<std::array<float, 3>> traj;
             traj.reserve(npts);
             for (size_t j = 0; j < npts; ++j) {
               const TLorentzVector& p = particle.Position(j);
@@ -224,13 +224,12 @@ bool AIML::TrackIDPIDMap2h5::operator()(const input_pointer& in, output_pointer&
     ensure_file();
     write_mapping(in->ident());
     write_mapping_simchnl(in->ident());
-    if (m_save_mc_json) {
-      write_mc_json(in->ident());
-    }
+    if (m_save_mc_json) { write_mc_json(in->ident()); }
   }
   else {
-    log->warn("TrackIDPIDMap2h5: no track ID to PID mapping to write for frame {} - was visit() called?",
-              in->ident());
+    log->warn(
+      "TrackIDPIDMap2h5: no track ID to PID mapping to write for frame {} - was visit() called?",
+      in->ident());
   }
 
   return true;
@@ -280,17 +279,18 @@ void AIML::TrackIDPIDMap2h5::populate_trackid_pid_map()
             }
           }
           catch (const cet::exception& ex) {
-            log->debug("TrackIDPIDMap2h5: pi_serv lookup failed for track {}: {}",
-                       track_id, ex.what());
+            log->debug(
+              "TrackIDPIDMap2h5: pi_serv lookup failed for track {}: {}", track_id, ex.what());
           }
-          m_simchnl_trackid_to_pid[track_id]       = pid;
-          m_simchnl_trackid_to_motherid[track_id]  = mother_id;
-          m_simchnl_trackid_to_process[track_id]   = process_code;
+          m_simchnl_trackid_to_pid[track_id] = pid;
+          m_simchnl_trackid_to_motherid[track_id] = mother_id;
+          m_simchnl_trackid_to_process[track_id] = process_code;
           m_simchnl_trackid_to_motherpid[track_id] = mother_pdg;
         }
       }
     }
-    log->info("TrackIDPIDMap2h5: SimChannel-based map has {} entries", m_simchnl_trackid_to_pid.size());
+    log->info("TrackIDPIDMap2h5: SimChannel-based map has {} entries",
+              m_simchnl_trackid_to_pid.size());
   }
   catch (const cet::exception& ex) {
     log->warn("TrackIDPIDMap2h5: ParticleInventoryService unavailable: {}", ex.what());
@@ -332,54 +332,77 @@ void AIML::TrackIDPIDMap2h5::ensure_file()
   m_file = H5Fopen(m_output_file.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
   if (m_file < 0) {
     m_file = H5Fcreate(m_output_file.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-    if (m_file < 0) {
-      log->error("TrackIDPIDMap2h5 failed to open output file {}", m_output_file);
-    }
+    if (m_file < 0) { log->error("TrackIDPIDMap2h5 failed to open output file {}", m_output_file); }
   }
 }
 
 // Helper: write a set of parallel int/float arrays into an HDF5 group
 namespace {
-  void h5_write_int(hid_t file, hid_t dataspace, hid_t lcpl,
-                    const std::string& name, const std::vector<int>& data,
+  void h5_write_int(hid_t file,
+                    hid_t dataspace,
+                    hid_t lcpl,
+                    const std::string& name,
+                    const std::vector<int>& data,
                     WireCell::Log::logptr_t log)
   {
-    hid_t dset = H5Dcreate2(file, name.c_str(), H5T_NATIVE_INT, dataspace, lcpl, H5P_DEFAULT, H5P_DEFAULT);
+    hid_t dset =
+      H5Dcreate2(file, name.c_str(), H5T_NATIVE_INT, dataspace, lcpl, H5P_DEFAULT, H5P_DEFAULT);
     if (dset >= 0) {
       if (H5Dwrite(dset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data.data()) < 0)
         log->warn("TrackIDPIDMap2h5 failed to write {}", name);
       H5Dclose(dset);
-    } else { log->warn("TrackIDPIDMap2h5 failed to create {}", name); }
+    }
+    else {
+      log->warn("TrackIDPIDMap2h5 failed to create {}", name);
+    }
   }
-  void h5_write_float(hid_t file, hid_t dataspace, hid_t lcpl,
-                      const std::string& name, const std::vector<float>& data,
+  void h5_write_float(hid_t file,
+                      hid_t dataspace,
+                      hid_t lcpl,
+                      const std::string& name,
+                      const std::vector<float>& data,
                       WireCell::Log::logptr_t log)
   {
-    hid_t dset = H5Dcreate2(file, name.c_str(), H5T_NATIVE_FLOAT, dataspace, lcpl, H5P_DEFAULT, H5P_DEFAULT);
+    hid_t dset =
+      H5Dcreate2(file, name.c_str(), H5T_NATIVE_FLOAT, dataspace, lcpl, H5P_DEFAULT, H5P_DEFAULT);
     if (dset >= 0) {
       if (H5Dwrite(dset, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data.data()) < 0)
         log->warn("TrackIDPIDMap2h5 failed to write {}", name);
       H5Dclose(dset);
-    } else { log->warn("TrackIDPIDMap2h5 failed to create {}", name); }
+    }
+    else {
+      log->warn("TrackIDPIDMap2h5 failed to create {}", name);
+    }
   }
   // Write a [N,4] float dataset (e.g. start/end XYZT positions)
-  void h5_write_float_2d(hid_t file, hid_t lcpl,
+  void h5_write_float_2d(hid_t file,
+                         hid_t lcpl,
                          const std::string& name,
-                         const std::vector<std::array<float,4>>& data,
+                         const std::vector<std::array<float, 4>>& data,
                          WireCell::Log::logptr_t log)
   {
     hsize_t dims[2] = {data.size(), 4};
     hid_t ds = H5Screate_simple(2, dims, nullptr);
-    if (ds < 0) { log->warn("TrackIDPIDMap2h5 failed to create dataspace for {}", name); return; }
-    hid_t dset = H5Dcreate2(file, name.c_str(), H5T_NATIVE_FLOAT, ds, lcpl, H5P_DEFAULT, H5P_DEFAULT);
+    if (ds < 0) {
+      log->warn("TrackIDPIDMap2h5 failed to create dataspace for {}", name);
+      return;
+    }
+    hid_t dset =
+      H5Dcreate2(file, name.c_str(), H5T_NATIVE_FLOAT, ds, lcpl, H5P_DEFAULT, H5P_DEFAULT);
     if (dset >= 0) {
       std::vector<float> flat;
       flat.reserve(data.size() * 4);
-      for (auto const& a : data) { for (float v : a) flat.push_back(v); }
+      for (auto const& a : data) {
+        for (float v : a)
+          flat.push_back(v);
+      }
       if (H5Dwrite(dset, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, flat.data()) < 0)
         log->warn("TrackIDPIDMap2h5 failed to write {}", name);
       H5Dclose(dset);
-    } else { log->warn("TrackIDPIDMap2h5 failed to create {}", name); }
+    }
+    else {
+      log->warn("TrackIDPIDMap2h5 failed to create {}", name);
+    }
     H5Sclose(ds);
   }
 } // anonymous namespace
@@ -391,23 +414,25 @@ void AIML::TrackIDPIDMap2h5::write_mapping(int frame_ident)
 
   std::vector<int> track_ids;
   track_ids.reserve(m_trackid_to_pid.size());
-  for (auto const& entry : m_trackid_to_pid) { track_ids.push_back(entry.first); }
+  for (auto const& entry : m_trackid_to_pid) {
+    track_ids.push_back(entry.first);
+  }
   std::sort(track_ids.begin(), track_ids.end());
 
   const size_t n = track_ids.size();
   std::vector<int> pids(n), mother_ids(n), processes(n), mother_pids(n);
-  std::vector<std::array<float,4>> starts(n), ends(n), start_moms(n), end_moms(n);
-  const std::array<float,4> zero4 = {0.f, 0.f, 0.f, 0.f};
+  std::vector<std::array<float, 4>> starts(n), ends(n), start_moms(n), end_moms(n);
+  const std::array<float, 4> zero4 = {0.f, 0.f, 0.f, 0.f};
   for (size_t i = 0; i < n; ++i) {
     int tid = track_ids[i];
-    pids[i]        = m_trackid_to_pid.at(tid);
-    mother_ids[i]  = m_trackid_to_motherid.count(tid)  ? m_trackid_to_motherid.at(tid)  : 0;
-    processes[i]   = m_trackid_to_process.count(tid)   ? m_trackid_to_process.at(tid)   : -1;
+    pids[i] = m_trackid_to_pid.at(tid);
+    mother_ids[i] = m_trackid_to_motherid.count(tid) ? m_trackid_to_motherid.at(tid) : 0;
+    processes[i] = m_trackid_to_process.count(tid) ? m_trackid_to_process.at(tid) : -1;
     mother_pids[i] = m_trackid_to_motherpid.count(tid) ? m_trackid_to_motherpid.at(tid) : 0;
-    starts[i]      = m_trackid_to_start.count(tid)     ? m_trackid_to_start.at(tid)     : zero4;
-    ends[i]        = m_trackid_to_end.count(tid)       ? m_trackid_to_end.at(tid)       : zero4;
-    start_moms[i]  = m_trackid_to_startmom.count(tid)  ? m_trackid_to_startmom.at(tid)  : zero4;
-    end_moms[i]    = m_trackid_to_endmom.count(tid)    ? m_trackid_to_endmom.at(tid)    : zero4;
+    starts[i] = m_trackid_to_start.count(tid) ? m_trackid_to_start.at(tid) : zero4;
+    ends[i] = m_trackid_to_end.count(tid) ? m_trackid_to_end.at(tid) : zero4;
+    start_moms[i] = m_trackid_to_startmom.count(tid) ? m_trackid_to_startmom.at(tid) : zero4;
+    end_moms[i] = m_trackid_to_endmom.count(tid) ? m_trackid_to_endmom.at(tid) : zero4;
   }
 
   const hsize_t dims[1] = {n};
@@ -415,41 +440,44 @@ void AIML::TrackIDPIDMap2h5::write_mapping(int frame_ident)
   hid_t lcpl = H5Pcreate(H5P_LINK_CREATE);
   H5Pset_create_intermediate_group(lcpl, 1);
   hid_t dataspace = H5Screate_simple(1, dims, nullptr);
-  if (dataspace < 0) { H5Pclose(lcpl); return; }
+  if (dataspace < 0) {
+    H5Pclose(lcpl);
+    return;
+  }
 
-  h5_write_int(m_file, dataspace, lcpl, grp + "/track_ids",   track_ids,   log);
-  h5_write_int(m_file, dataspace, lcpl, grp + "/pids",        pids,        log);
-  h5_write_int(m_file, dataspace, lcpl, grp + "/mother_ids",  mother_ids,  log);
-  h5_write_int(m_file, dataspace, lcpl, grp + "/processes",   processes,   log);
+  h5_write_int(m_file, dataspace, lcpl, grp + "/track_ids", track_ids, log);
+  h5_write_int(m_file, dataspace, lcpl, grp + "/pids", pids, log);
+  h5_write_int(m_file, dataspace, lcpl, grp + "/mother_ids", mother_ids, log);
+  h5_write_int(m_file, dataspace, lcpl, grp + "/processes", processes, log);
   h5_write_int(m_file, dataspace, lcpl, grp + "/mother_pids", mother_pids, log);
 
   H5Sclose(dataspace);
   // Write [N,4] start/end position datasets
   h5_write_float_2d(m_file, lcpl, grp + "/start_xyzts", starts, log);
-  h5_write_float_2d(m_file, lcpl, grp + "/end_xyzts",   ends,   log);
+  h5_write_float_2d(m_file, lcpl, grp + "/end_xyzts", ends, log);
   // Write [N,4] start/end momentum [px, py, pz, E] in GeV
-  h5_write_float_2d(m_file, lcpl, grp + "/start_moms",  start_moms, log);
-  h5_write_float_2d(m_file, lcpl, grp + "/end_moms",    end_moms,   log);
+  h5_write_float_2d(m_file, lcpl, grp + "/start_moms", start_moms, log);
+  h5_write_float_2d(m_file, lcpl, grp + "/end_moms", end_moms, log);
 
   // Extended MCParticle fields (gated by save_extended_mcpart config)
   if (m_save_extended_mcpart) {
-    std::vector<int>   end_processes(n), statuses(n), ndaughters(n), ntrajpts(n);
+    std::vector<int> end_processes(n), statuses(n), ndaughters(n), ntrajpts(n);
     std::vector<float> masses(n);
     for (size_t i = 0; i < n; ++i) {
       int tid = track_ids[i];
       end_processes[i] = m_trackid_to_endprocess.count(tid) ? m_trackid_to_endprocess.at(tid) : -1;
-      statuses[i]      = m_trackid_to_status.count(tid)     ? m_trackid_to_status.at(tid)     : 0;
-      masses[i]        = m_trackid_to_mass.count(tid)        ? m_trackid_to_mass.at(tid)       : 0.f;
-      ndaughters[i]    = m_trackid_to_ndaughters.count(tid)  ? m_trackid_to_ndaughters.at(tid) : 0;
-      ntrajpts[i]      = m_trackid_to_ntrajpts.count(tid)    ? m_trackid_to_ntrajpts.at(tid)   : 0;
+      statuses[i] = m_trackid_to_status.count(tid) ? m_trackid_to_status.at(tid) : 0;
+      masses[i] = m_trackid_to_mass.count(tid) ? m_trackid_to_mass.at(tid) : 0.f;
+      ndaughters[i] = m_trackid_to_ndaughters.count(tid) ? m_trackid_to_ndaughters.at(tid) : 0;
+      ntrajpts[i] = m_trackid_to_ntrajpts.count(tid) ? m_trackid_to_ntrajpts.at(tid) : 0;
     }
     hid_t ds_ext = H5Screate_simple(1, dims, nullptr);
     if (ds_ext >= 0) {
-      h5_write_int  (m_file, ds_ext, lcpl, grp + "/end_processes", end_processes, log);
-      h5_write_int  (m_file, ds_ext, lcpl, grp + "/statuses",      statuses,      log);
-      h5_write_float(m_file, ds_ext, lcpl, grp + "/masses",        masses,        log);
-      h5_write_int  (m_file, ds_ext, lcpl, grp + "/ndaughters",    ndaughters,    log);
-      h5_write_int  (m_file, ds_ext, lcpl, grp + "/ntrajpts",      ntrajpts,      log);
+      h5_write_int(m_file, ds_ext, lcpl, grp + "/end_processes", end_processes, log);
+      h5_write_int(m_file, ds_ext, lcpl, grp + "/statuses", statuses, log);
+      h5_write_float(m_file, ds_ext, lcpl, grp + "/masses", masses, log);
+      h5_write_int(m_file, ds_ext, lcpl, grp + "/ndaughters", ndaughters, log);
+      h5_write_int(m_file, ds_ext, lcpl, grp + "/ntrajpts", ntrajpts, log);
       H5Sclose(ds_ext);
     }
   }
@@ -466,19 +494,25 @@ void AIML::TrackIDPIDMap2h5::write_mapping_simchnl(int frame_ident)
 
   std::vector<int> track_ids;
   track_ids.reserve(m_simchnl_trackid_to_pid.size());
-  for (auto const& entry : m_simchnl_trackid_to_pid) { track_ids.push_back(entry.first); }
+  for (auto const& entry : m_simchnl_trackid_to_pid) {
+    track_ids.push_back(entry.first);
+  }
   std::sort(track_ids.begin(), track_ids.end());
 
   const size_t n = track_ids.size();
-  std::vector<int>   pids(n), mother_ids(n), processes(n), mother_pids(n);
+  std::vector<int> pids(n), mother_ids(n), processes(n), mother_pids(n);
   std::vector<float> energies(n);
   for (size_t i = 0; i < n; ++i) {
     int tid = track_ids[i];
-    pids[i]        = m_simchnl_trackid_to_pid.at(tid);
-    mother_ids[i]  = m_simchnl_trackid_to_motherid.count(tid)  ? m_simchnl_trackid_to_motherid.at(tid)  : 0;
-    processes[i]   = m_simchnl_trackid_to_process.count(tid)   ? m_simchnl_trackid_to_process.at(tid)   : -1;
-    mother_pids[i] = m_simchnl_trackid_to_motherpid.count(tid) ? m_simchnl_trackid_to_motherpid.at(tid) : 0;
-    energies[i]    = m_simchnl_trackid_to_energy.count(tid)    ? m_simchnl_trackid_to_energy.at(tid)    : 0.0f;
+    pids[i] = m_simchnl_trackid_to_pid.at(tid);
+    mother_ids[i] =
+      m_simchnl_trackid_to_motherid.count(tid) ? m_simchnl_trackid_to_motherid.at(tid) : 0;
+    processes[i] =
+      m_simchnl_trackid_to_process.count(tid) ? m_simchnl_trackid_to_process.at(tid) : -1;
+    mother_pids[i] =
+      m_simchnl_trackid_to_motherpid.count(tid) ? m_simchnl_trackid_to_motherpid.at(tid) : 0;
+    energies[i] =
+      m_simchnl_trackid_to_energy.count(tid) ? m_simchnl_trackid_to_energy.at(tid) : 0.0f;
   }
 
   const hsize_t dims[1] = {n};
@@ -486,14 +520,17 @@ void AIML::TrackIDPIDMap2h5::write_mapping_simchnl(int frame_ident)
   hid_t lcpl = H5Pcreate(H5P_LINK_CREATE);
   H5Pset_create_intermediate_group(lcpl, 1);
   hid_t dataspace = H5Screate_simple(1, dims, nullptr);
-  if (dataspace < 0) { H5Pclose(lcpl); return; }
+  if (dataspace < 0) {
+    H5Pclose(lcpl);
+    return;
+  }
 
-  h5_write_int  (m_file, dataspace, lcpl, grp + "/track_ids",   track_ids,   log);
-  h5_write_int  (m_file, dataspace, lcpl, grp + "/pids",        pids,        log);
-  h5_write_int  (m_file, dataspace, lcpl, grp + "/mother_ids",  mother_ids,  log);
-  h5_write_int  (m_file, dataspace, lcpl, grp + "/processes",   processes,   log);
-  h5_write_int  (m_file, dataspace, lcpl, grp + "/mother_pids", mother_pids, log);
-  h5_write_float(m_file, dataspace, lcpl, grp + "/energies",    energies,    log);
+  h5_write_int(m_file, dataspace, lcpl, grp + "/track_ids", track_ids, log);
+  h5_write_int(m_file, dataspace, lcpl, grp + "/pids", pids, log);
+  h5_write_int(m_file, dataspace, lcpl, grp + "/mother_ids", mother_ids, log);
+  h5_write_int(m_file, dataspace, lcpl, grp + "/processes", processes, log);
+  h5_write_int(m_file, dataspace, lcpl, grp + "/mother_pids", mother_pids, log);
+  h5_write_float(m_file, dataspace, lcpl, grp + "/energies", energies, log);
 
   H5Sclose(dataspace);
   H5Pclose(lcpl);
@@ -506,25 +543,25 @@ std::string AIML::TrackIDPIDMap2h5::pdg_name(int pdg)
 {
   // Common particles
   switch (pdg) {
-    case  11: return "e-";
-    case -11: return "e+";
-    case  13: return "mu-";
-    case -13: return "mu+";
-    case  22: return "gamma";
-    case 111: return "pi0";
-    case 211: return "pi+";
-    case -211: return "pi-";
-    case 321: return "K+";
-    case -321: return "K-";
-    case 2112: return "neutron";
-    case 2212: return "proton";
-    case  12: return "nu_e";
-    case -12: return "anti_nu_e";
-    case  14: return "nu_mu";
-    case -14: return "anti_nu_mu";
-    case  16: return "nu_tau";
-    case -16: return "anti_nu_tau";
-    default: break;
+  case 11: return "e-";
+  case -11: return "e+";
+  case 13: return "mu-";
+  case -13: return "mu+";
+  case 22: return "gamma";
+  case 111: return "pi0";
+  case 211: return "pi+";
+  case -211: return "pi-";
+  case 321: return "K+";
+  case -321: return "K-";
+  case 2112: return "neutron";
+  case 2212: return "proton";
+  case 12: return "nu_e";
+  case -12: return "anti_nu_e";
+  case 14: return "nu_mu";
+  case -14: return "anti_nu_mu";
+  case 16: return "nu_tau";
+  case -16: return "anti_nu_tau";
+  default: break;
   }
   // Nuclear codes: 10LZZZAAAI
   if (pdg > 1000000000) {
@@ -532,18 +569,18 @@ std::string AIML::TrackIDPIDMap2h5::pdg_name(int pdg)
     int a = (pdg - 1000000000 - z * 10000) / 10;
     const char* elem = "";
     switch (z) {
-      case 1:  elem = "H";  break;
-      case 2:  elem = "He"; break;
-      case 6:  elem = "C";  break;
-      case 8:  elem = "O";  break;
-      case 14: elem = "Si"; break;
-      case 15: elem = "P";  break;
-      case 16: elem = "S";  break;
-      case 17: elem = "Cl"; break;
-      case 18: elem = "Ar"; break;
-      case 19: elem = "K";  break;
-      case 20: elem = "Ca"; break;
-      default: return std::to_string(pdg);
+    case 1: elem = "H"; break;
+    case 2: elem = "He"; break;
+    case 6: elem = "C"; break;
+    case 8: elem = "O"; break;
+    case 14: elem = "Si"; break;
+    case 15: elem = "P"; break;
+    case 16: elem = "S"; break;
+    case 17: elem = "Cl"; break;
+    case 18: elem = "Ar"; break;
+    case 19: elem = "K"; break;
+    case 20: elem = "Ca"; break;
+    default: return std::to_string(pdg);
     }
     return std::string(elem) + "-" + std::to_string(a);
   }
@@ -568,16 +605,14 @@ bool AIML::TrackIDPIDMap2h5::keep_mc(int tid) const
     const auto& mom = mit->second;
     double E = mom[3];
     double px = mom[0], py = mom[1], pz = mom[2];
-    double mass = std::sqrt(std::max(0.0, E*E - px*px - py*py - pz*pz));
+    double mass = std::sqrt(std::max(0.0, E * E - px * px - py * py - pz * pz));
     ke_mev = (E - mass) * 1000.0;
   }
 
   double thresh_KE_em = 5.0;  // MeV for gamma/e+/e-
   double thresh_KE_np = 50.0; // MeV for neutron/proton/nuclei
 
-  if (pdg == 22 || pdg == 11 || pdg == -11) {
-    return ke_mev >= thresh_KE_em;
-  }
+  if (pdg == 22 || pdg == 11 || pdg == -11) { return ke_mev >= thresh_KE_em; }
   else if (pdg == 2112 || pdg == 2212 || pdg > 1000000000) {
     return ke_mev >= thresh_KE_np;
   }
@@ -598,7 +633,7 @@ bool AIML::TrackIDPIDMap2h5::dump_mc_json_node(int tid, std::ostream& out) const
     const auto& mom = mit->second;
     double E = mom[3];
     double px = mom[0], py = mom[1], pz = mom[2];
-    double mass = std::sqrt(std::max(0.0, E*E - px*px - py*py - pz*pz));
+    double mass = std::sqrt(std::max(0.0, E * E - px * px - py * py - pz * pz));
     ke_mev = static_cast<int>((E - mass) * 1000.0);
   }
 
@@ -613,11 +648,20 @@ bool AIML::TrackIDPIDMap2h5::dump_mc_json_node(int tid, std::ostream& out) const
   if (tit != m_trackid_to_traj.end() && !tit->second.empty()) {
     const auto& traj = tit->second;
     out << "\"traj_x\":[";
-    for (size_t j = 0; j < traj.size(); ++j) { if (j) out << ","; out << traj[j][0]; }
+    for (size_t j = 0; j < traj.size(); ++j) {
+      if (j) out << ",";
+      out << traj[j][0];
+    }
     out << "],\"traj_y\":[";
-    for (size_t j = 0; j < traj.size(); ++j) { if (j) out << ","; out << traj[j][1]; }
+    for (size_t j = 0; j < traj.size(); ++j) {
+      if (j) out << ",";
+      out << traj[j][1];
+    }
     out << "],\"traj_z\":[";
-    for (size_t j = 0; j < traj.size(); ++j) { if (j) out << ","; out << traj[j][2]; }
+    for (size_t j = 0; j < traj.size(); ++j) {
+      if (j) out << ",";
+      out << traj[j][2];
+    }
     out << "],";
   }
 
@@ -625,7 +669,8 @@ bool AIML::TrackIDPIDMap2h5::dump_mc_json_node(int tid, std::ostream& out) const
   auto sit = m_trackid_to_start.find(tid);
   auto eit = m_trackid_to_end.find(tid);
   if (sit != m_trackid_to_start.end()) {
-    out << "\"start\":[" << sit->second[0] << ", " << sit->second[1] << ", " << sit->second[2] << "],";
+    out << "\"start\":[" << sit->second[0] << ", " << sit->second[1] << ", " << sit->second[2]
+        << "],";
   }
   if (eit != m_trackid_to_end.end()) {
     out << "\"end\":[" << eit->second[0] << ", " << eit->second[1] << ", " << eit->second[2] << "]";
@@ -637,9 +682,7 @@ bool AIML::TrackIDPIDMap2h5::dump_mc_json_node(int tid, std::ostream& out) const
   auto dit = m_trackid_to_daughters.find(tid);
   if (dit != m_trackid_to_daughters.end()) {
     for (int d : dit->second) {
-      if (m_trackid_to_pid.count(d) && keep_mc(d)) {
-        saved_daughters.push_back(d);
-      }
+      if (m_trackid_to_pid.count(d) && keep_mc(d)) { saved_daughters.push_back(d); }
     }
   }
 
@@ -664,9 +707,7 @@ void AIML::TrackIDPIDMap2h5::dump_mc_json(std::ostream& out) const
   // Find primaries (mother == 0) that pass KeepMC
   std::vector<int> primaries;
   for (auto const& [tid, motherid] : m_trackid_to_motherid) {
-    if (motherid == 0 && keep_mc(tid)) {
-      primaries.push_back(tid);
-    }
+    if (motherid == 0 && keep_mc(tid)) { primaries.push_back(tid); }
   }
   std::sort(primaries.begin(), primaries.end());
 

--- a/larwirecell/aiml/TrackIDPIDMap2h5.cxx
+++ b/larwirecell/aiml/TrackIDPIDMap2h5.cxx
@@ -1,0 +1,705 @@
+#include "TrackIDPIDMap2h5.h"
+#include "WireCellUtil/Configuration.h"
+#include "WireCellUtil/NamedFactory.h"
+
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "canvas/Utilities/InputTag.h"
+#include "cetlib_except/exception.h"
+#include "larsim/MCCheater/ParticleInventoryService.h"
+#include "nusimdata/SimulationBase/MCParticle.h"
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <hdf5.h>
+#include <iomanip>
+#include <map>
+#include <sstream>
+#include <string>
+#include <sys/stat.h>
+
+WIRECELL_FACTORY(TrackIDPIDMap2h5,
+                 WireCell::AIML::TrackIDPIDMap2h5,
+                 WireCell::INamed,
+                 WireCell::IFrameFilter,
+                 WireCell::IConfigurable)
+
+using namespace WireCell;
+
+// G4 process name → integer code mapping (following CellTree convention)
+const std::map<std::string, int> AIML::TrackIDPIDMap2h5::s_process_map = {
+  {"primary",                  0},
+  {"Decay",                    1},
+  {"eIoni",                    2},
+  {"muIoni",                   3},
+  {"eBrem",                    4},
+  {"compt",                    5},
+  {"phot",                     6},
+  {"conv",                     7},
+  {"hIoni",                    8},
+  {"nCapture",                 9},
+  {"muPairProd",              10},
+  {"CoulombScat",             11},
+  {"muBrems",                 12},
+  {"LowEnConversion",         13},
+  {"annihil",                 14},
+  {"neutronInelastic",        15},
+  {"hadElastic",              16},
+  {"hBertiniCaptureAtRest",   17},
+  {"muMinusCaptureAtRest",    18},
+  {"protonInelastic",         19},
+  {"pi+Inelastic",            20},
+  {"pi-Inelastic",            21},
+  {"PhotonInelastic",         22},
+  {"CHIPSNuclearCaptureAtRest", 23},
+  {"Transportation",           24},
+  {"kaon+Inelastic",           25},
+  {"kaon-Inelastic",           26},
+  {"kaon0LInelastic",          27},
+  {"ionInelastic",             28},
+  {"Scintillation",            29},
+  {"ionIoni",                  30},
+  {"nKiller",                  31},
+  {"StepLimiter",              32},
+  {"dInelastic",               33},
+};
+
+AIML::TrackIDPIDMap2h5::TrackIDPIDMap2h5()
+  : Aux::Logger("TrackIDPIDMap2h5", "aiml")
+  , m_simchannel_label("tpcrawdecoder:simpleSC")
+  , m_particle_label("largeant")
+  , m_output_file("trackid_pid_map.h5")
+  , m_file(-1)
+{}
+
+AIML::TrackIDPIDMap2h5::~TrackIDPIDMap2h5()
+{
+  if (m_file >= 0) {
+    H5Fclose(m_file);
+    m_file = -1;
+  }
+}
+
+Configuration AIML::TrackIDPIDMap2h5::default_configuration() const
+{
+  Configuration cfg;
+  cfg["simchannel_label"] = m_simchannel_label;
+  cfg["particle_label"] = m_particle_label;
+  cfg["output_file"] = m_output_file;
+  cfg["save_mc_json"] = m_save_mc_json;
+  cfg["save_extended_mcpart"] = m_save_extended_mcpart;
+  return cfg;
+}
+
+void AIML::TrackIDPIDMap2h5::configure(const Configuration& cfg)
+{
+  m_simchannel_label = get(cfg, "simchannel_label", m_simchannel_label);
+  m_particle_label = get(cfg, "particle_label", m_particle_label);
+  m_output_file = get(cfg, "output_file", m_output_file);
+  m_save_mc_json = get(cfg, "save_mc_json", m_save_mc_json);
+  m_save_extended_mcpart = get(cfg, "save_extended_mcpart", m_save_extended_mcpart);
+
+  clear_cache();
+  if (m_file >= 0) {
+    H5Fclose(m_file);
+    m_file = -1;
+  }
+}
+
+void AIML::TrackIDPIDMap2h5::visit(art::Event& event)
+{
+  log->info("TrackIDPIDMap2h5::visit called for event: {}", event.event());
+  clear_cache();
+
+  // --- Step 1: Read all MCParticles to get complete truth coverage ---
+  // This covers ALL Geant4-tracked particles, not just TPC ionizers.
+  if (!m_particle_label.empty()) {
+    art::Handle<std::vector<simb::MCParticle>> particle_handle;
+    if (event.getByLabel(art::InputTag{m_particle_label}, particle_handle)) {
+      log->debug("TrackIDPIDMap2h5: Got {} MCParticles", particle_handle->size());
+      for (auto const& particle : *particle_handle) {
+        int tid = particle.TrackId();
+        if (tid == 0) { continue; }
+        m_trackid_to_pid[tid]      = particle.PdgCode();
+        m_trackid_to_motherid[tid] = particle.Mother();
+        // Map G4 process name to integer code; -1 for unknown
+        auto it = s_process_map.find(particle.Process());
+        if (it == s_process_map.end()) {
+            std::cout << "Process not in map: tid=" << tid
+                      << " pdg=" << particle.PdgCode()
+                      << " process=\"" << particle.Process() << "\"\n";
+        }
+        m_trackid_to_process[tid] = (it != s_process_map.end()) ? it->second : -1;
+        // Start/end positions and momentum from trajectory
+        {
+          size_t npts = particle.NumberTrajectoryPoints();
+          const TLorentzVector& s4 = particle.Position(0);
+          const TLorentzVector& e4 = particle.Position(npts - 1);
+          m_trackid_to_start[tid] = {(float)s4.X(), (float)s4.Y(), (float)s4.Z(), (float)s4.T()};
+          m_trackid_to_end[tid]   = {(float)e4.X(), (float)e4.Y(), (float)e4.Z(), (float)e4.T()};
+          const TLorentzVector& mom0 = particle.Momentum(0);
+          m_trackid_to_startmom[tid] = {(float)mom0.Px(), (float)mom0.Py(), (float)mom0.Pz(), (float)mom0.E()};
+          const TLorentzVector& momN = particle.Momentum(npts - 1);
+          m_trackid_to_endmom[tid] = {(float)momN.Px(), (float)momN.Py(), (float)momN.Pz(), (float)momN.E()};
+          // Daughters
+          std::vector<int> daughters;
+          for (int d = 0; d < particle.NumberDaughters(); ++d) {
+            daughters.push_back(particle.Daughter(d));
+          }
+          m_trackid_to_daughters[tid] = std::move(daughters);
+          // Extended fields (gated by config flag)
+          if (m_save_extended_mcpart) {
+            auto eit = s_process_map.find(particle.EndProcess());
+            if (eit == s_process_map.end() && !particle.EndProcess().empty()) {
+              std::cout << "EndProcess not in map: tid=" << tid
+                        << " pdg=" << particle.PdgCode()
+                        << " endprocess=\"" << particle.EndProcess() << "\"\n";
+            }
+            m_trackid_to_endprocess[tid] = (eit != s_process_map.end()) ? eit->second : -1;
+            m_trackid_to_status[tid]     = particle.StatusCode();
+            m_trackid_to_mass[tid]       = (float)particle.Mass();
+            m_trackid_to_ndaughters[tid] = particle.NumberDaughters();
+            m_trackid_to_ntrajpts[tid]   = (int)npts;
+          }
+          // Trajectory points (for JSON visualization)
+          if (m_save_mc_json) {
+            std::vector<std::array<float,3>> traj;
+            traj.reserve(npts);
+            for (size_t j = 0; j < npts; ++j) {
+              const TLorentzVector& p = particle.Position(j);
+              traj.push_back({(float)p.X(), (float)p.Y(), (float)p.Z()});
+            }
+            m_trackid_to_traj[tid] = std::move(traj);
+          }
+        }
+      }
+      // Second pass: fill mother's PDG (requires full pid map built above)
+      for (auto const& [tid, motherid] : m_trackid_to_motherid) {
+        int mother_pdg = 0;
+        if (motherid != 0) {
+          auto mit = m_trackid_to_pid.find(motherid);
+          if (mit != m_trackid_to_pid.end()) { mother_pdg = mit->second; }
+        }
+        m_trackid_to_motherpid[tid] = mother_pdg;
+      }
+    }
+    else {
+      log->warn("TrackIDPIDMap2h5 failed to fetch MCParticle with label '{}'", m_particle_label);
+    }
+  }
+
+  // --- Step 2: Read SimChannel to accumulate energy fractions ---
+  // Also ensures any trackID present only in SimChannel (e.g. shower secondaries
+  // with modified IDs) is still recorded.
+  if (!m_simchannel_label.empty()) {
+    art::Handle<std::vector<sim::SimChannel>> handle;
+    if (event.getByLabel(art::InputTag{m_simchannel_label}, handle)) {
+      log->debug("TrackIDPIDMap2h5: Got {} SimChannels", handle->size());
+      cache_simchannels(*handle);
+      populate_trackid_pid_map();
+    }
+    else {
+      log->warn("TrackIDPIDMap2h5 failed to fetch SimChannel with label '{}'", m_simchannel_label);
+    }
+  }
+
+  log->info("TrackIDPIDMap2h5 cached {} track->pid entries", m_trackid_to_pid.size());
+}
+
+bool AIML::TrackIDPIDMap2h5::operator()(const input_pointer& in, output_pointer& out)
+{
+  out = in;
+  if (!in) {
+    log->debug("TrackIDPIDMap2h5: null input frame");
+    return true;
+  }
+
+  log->info("TrackIDPIDMap2h5::operator() called for frame {}, have {} track->pid entries",
+            in->ident(),
+            m_trackid_to_pid.size());
+
+  if (!m_trackid_to_pid.empty() || !m_simchnl_trackid_to_pid.empty()) {
+    ensure_file();
+    write_mapping(in->ident());
+    write_mapping_simchnl(in->ident());
+    if (m_save_mc_json) {
+      write_mc_json(in->ident());
+    }
+  }
+  else {
+    log->warn("TrackIDPIDMap2h5: no track ID to PID mapping to write for frame {} - was visit() called?",
+              in->ident());
+  }
+
+  return true;
+}
+
+void AIML::TrackIDPIDMap2h5::cache_simchannels(const std::vector<sim::SimChannel>& simchs)
+{
+  m_simchannels = simchs;
+}
+
+void AIML::TrackIDPIDMap2h5::populate_trackid_pid_map()
+{
+  // Fill the SimChannel-based maps using ParticleInventoryService.
+  // These cover only tracks that ionized in the TPC (including EM shower daughters
+  // that are absent from the MCParticle list when keepEMShowerDaughters=false).
+  if (m_simchannels.empty()) { return; }
+
+  try {
+    art::ServiceHandle<cheat::ParticleInventoryService> pi_serv;
+    for (auto const& sc : m_simchannels) {
+      for (auto const& tdc_entry : sc.TDCIDEMap()) {
+        for (auto const& ide : tdc_entry.second) {
+          const int track_id = ide.trackID;
+          if (track_id == 0) { continue; }
+
+          // Accumulate deposited energy [MeV] across all channels/TDCs
+          m_simchnl_trackid_to_energy[track_id] += ide.energy;
+
+          // Only look up once per trackID
+          if (m_simchnl_trackid_to_pid.count(track_id)) { continue; }
+
+          int pid = 0;
+          int mother_id = 0;
+          int process_code = -1;
+          int mother_pdg = 0;
+          try {
+            auto const particle = pi_serv->TrackIdToParticle_P(track_id);
+            if (particle) {
+              pid = particle->PdgCode();
+              mother_id = particle->Mother();
+              auto it = s_process_map.find(particle->Process());
+              process_code = (it != s_process_map.end()) ? it->second : -1;
+              if (mother_id != 0) {
+                auto const mother = pi_serv->TrackIdToParticle_P(mother_id);
+                if (mother) { mother_pdg = mother->PdgCode(); }
+              }
+            }
+          }
+          catch (const cet::exception& ex) {
+            log->debug("TrackIDPIDMap2h5: pi_serv lookup failed for track {}: {}",
+                       track_id, ex.what());
+          }
+          m_simchnl_trackid_to_pid[track_id]       = pid;
+          m_simchnl_trackid_to_motherid[track_id]  = mother_id;
+          m_simchnl_trackid_to_process[track_id]   = process_code;
+          m_simchnl_trackid_to_motherpid[track_id] = mother_pdg;
+        }
+      }
+    }
+    log->info("TrackIDPIDMap2h5: SimChannel-based map has {} entries", m_simchnl_trackid_to_pid.size());
+  }
+  catch (const cet::exception& ex) {
+    log->warn("TrackIDPIDMap2h5: ParticleInventoryService unavailable: {}", ex.what());
+  }
+}
+
+void AIML::TrackIDPIDMap2h5::clear_cache()
+{
+  m_simchannels.clear();
+  // MCParticle-based maps
+  m_trackid_to_pid.clear();
+  m_trackid_to_motherid.clear();
+  m_trackid_to_process.clear();
+  m_trackid_to_motherpid.clear();
+  m_trackid_to_start.clear();
+  m_trackid_to_end.clear();
+  m_trackid_to_startmom.clear();
+  m_trackid_to_endmom.clear();
+  m_trackid_to_daughters.clear();
+  m_trackid_to_traj.clear();
+  // Extended MCParticle maps
+  m_trackid_to_endprocess.clear();
+  m_trackid_to_status.clear();
+  m_trackid_to_mass.clear();
+  m_trackid_to_ndaughters.clear();
+  m_trackid_to_ntrajpts.clear();
+  // SimChannel-based maps
+  m_simchnl_trackid_to_pid.clear();
+  m_simchnl_trackid_to_motherid.clear();
+  m_simchnl_trackid_to_process.clear();
+  m_simchnl_trackid_to_motherpid.clear();
+  m_simchnl_trackid_to_energy.clear();
+}
+
+void AIML::TrackIDPIDMap2h5::ensure_file()
+{
+  if (m_file >= 0) { return; }
+
+  m_file = H5Fopen(m_output_file.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
+  if (m_file < 0) {
+    m_file = H5Fcreate(m_output_file.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    if (m_file < 0) {
+      log->error("TrackIDPIDMap2h5 failed to open output file {}", m_output_file);
+    }
+  }
+}
+
+// Helper: write a set of parallel int/float arrays into an HDF5 group
+namespace {
+  void h5_write_int(hid_t file, hid_t dataspace, hid_t lcpl,
+                    const std::string& name, const std::vector<int>& data,
+                    WireCell::Log::logptr_t log)
+  {
+    hid_t dset = H5Dcreate2(file, name.c_str(), H5T_NATIVE_INT, dataspace, lcpl, H5P_DEFAULT, H5P_DEFAULT);
+    if (dset >= 0) {
+      if (H5Dwrite(dset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data.data()) < 0)
+        log->warn("TrackIDPIDMap2h5 failed to write {}", name);
+      H5Dclose(dset);
+    } else { log->warn("TrackIDPIDMap2h5 failed to create {}", name); }
+  }
+  void h5_write_float(hid_t file, hid_t dataspace, hid_t lcpl,
+                      const std::string& name, const std::vector<float>& data,
+                      WireCell::Log::logptr_t log)
+  {
+    hid_t dset = H5Dcreate2(file, name.c_str(), H5T_NATIVE_FLOAT, dataspace, lcpl, H5P_DEFAULT, H5P_DEFAULT);
+    if (dset >= 0) {
+      if (H5Dwrite(dset, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data.data()) < 0)
+        log->warn("TrackIDPIDMap2h5 failed to write {}", name);
+      H5Dclose(dset);
+    } else { log->warn("TrackIDPIDMap2h5 failed to create {}", name); }
+  }
+  // Write a [N,4] float dataset (e.g. start/end XYZT positions)
+  void h5_write_float_2d(hid_t file, hid_t lcpl,
+                         const std::string& name,
+                         const std::vector<std::array<float,4>>& data,
+                         WireCell::Log::logptr_t log)
+  {
+    hsize_t dims[2] = {data.size(), 4};
+    hid_t ds = H5Screate_simple(2, dims, nullptr);
+    if (ds < 0) { log->warn("TrackIDPIDMap2h5 failed to create dataspace for {}", name); return; }
+    hid_t dset = H5Dcreate2(file, name.c_str(), H5T_NATIVE_FLOAT, ds, lcpl, H5P_DEFAULT, H5P_DEFAULT);
+    if (dset >= 0) {
+      std::vector<float> flat;
+      flat.reserve(data.size() * 4);
+      for (auto const& a : data) { for (float v : a) flat.push_back(v); }
+      if (H5Dwrite(dset, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, flat.data()) < 0)
+        log->warn("TrackIDPIDMap2h5 failed to write {}", name);
+      H5Dclose(dset);
+    } else { log->warn("TrackIDPIDMap2h5 failed to create {}", name); }
+    H5Sclose(ds);
+  }
+} // anonymous namespace
+
+void AIML::TrackIDPIDMap2h5::write_mapping(int frame_ident)
+{
+  // Writes MCParticle-based truth (all stored G4 tracks) under /<frame_ident>/mcpart/
+  if (m_file < 0 || m_trackid_to_pid.empty()) { return; }
+
+  std::vector<int> track_ids;
+  track_ids.reserve(m_trackid_to_pid.size());
+  for (auto const& entry : m_trackid_to_pid) { track_ids.push_back(entry.first); }
+  std::sort(track_ids.begin(), track_ids.end());
+
+  const size_t n = track_ids.size();
+  std::vector<int> pids(n), mother_ids(n), processes(n), mother_pids(n);
+  std::vector<std::array<float,4>> starts(n), ends(n), start_moms(n), end_moms(n);
+  const std::array<float,4> zero4 = {0.f, 0.f, 0.f, 0.f};
+  for (size_t i = 0; i < n; ++i) {
+    int tid = track_ids[i];
+    pids[i]        = m_trackid_to_pid.at(tid);
+    mother_ids[i]  = m_trackid_to_motherid.count(tid)  ? m_trackid_to_motherid.at(tid)  : 0;
+    processes[i]   = m_trackid_to_process.count(tid)   ? m_trackid_to_process.at(tid)   : -1;
+    mother_pids[i] = m_trackid_to_motherpid.count(tid) ? m_trackid_to_motherpid.at(tid) : 0;
+    starts[i]      = m_trackid_to_start.count(tid)     ? m_trackid_to_start.at(tid)     : zero4;
+    ends[i]        = m_trackid_to_end.count(tid)       ? m_trackid_to_end.at(tid)       : zero4;
+    start_moms[i]  = m_trackid_to_startmom.count(tid)  ? m_trackid_to_startmom.at(tid)  : zero4;
+    end_moms[i]    = m_trackid_to_endmom.count(tid)    ? m_trackid_to_endmom.at(tid)    : zero4;
+  }
+
+  const hsize_t dims[1] = {n};
+  const std::string grp = "/" + std::to_string(frame_ident) + "/mcpart";
+  hid_t lcpl = H5Pcreate(H5P_LINK_CREATE);
+  H5Pset_create_intermediate_group(lcpl, 1);
+  hid_t dataspace = H5Screate_simple(1, dims, nullptr);
+  if (dataspace < 0) { H5Pclose(lcpl); return; }
+
+  h5_write_int(m_file, dataspace, lcpl, grp + "/track_ids",   track_ids,   log);
+  h5_write_int(m_file, dataspace, lcpl, grp + "/pids",        pids,        log);
+  h5_write_int(m_file, dataspace, lcpl, grp + "/mother_ids",  mother_ids,  log);
+  h5_write_int(m_file, dataspace, lcpl, grp + "/processes",   processes,   log);
+  h5_write_int(m_file, dataspace, lcpl, grp + "/mother_pids", mother_pids, log);
+
+  H5Sclose(dataspace);
+  // Write [N,4] start/end position datasets
+  h5_write_float_2d(m_file, lcpl, grp + "/start_xyzts", starts, log);
+  h5_write_float_2d(m_file, lcpl, grp + "/end_xyzts",   ends,   log);
+  // Write [N,4] start/end momentum [px, py, pz, E] in GeV
+  h5_write_float_2d(m_file, lcpl, grp + "/start_moms",  start_moms, log);
+  h5_write_float_2d(m_file, lcpl, grp + "/end_moms",    end_moms,   log);
+
+  // Extended MCParticle fields (gated by save_extended_mcpart config)
+  if (m_save_extended_mcpart) {
+    std::vector<int>   end_processes(n), statuses(n), ndaughters(n), ntrajpts(n);
+    std::vector<float> masses(n);
+    for (size_t i = 0; i < n; ++i) {
+      int tid = track_ids[i];
+      end_processes[i] = m_trackid_to_endprocess.count(tid) ? m_trackid_to_endprocess.at(tid) : -1;
+      statuses[i]      = m_trackid_to_status.count(tid)     ? m_trackid_to_status.at(tid)     : 0;
+      masses[i]        = m_trackid_to_mass.count(tid)        ? m_trackid_to_mass.at(tid)       : 0.f;
+      ndaughters[i]    = m_trackid_to_ndaughters.count(tid)  ? m_trackid_to_ndaughters.at(tid) : 0;
+      ntrajpts[i]      = m_trackid_to_ntrajpts.count(tid)    ? m_trackid_to_ntrajpts.at(tid)   : 0;
+    }
+    hid_t ds_ext = H5Screate_simple(1, dims, nullptr);
+    if (ds_ext >= 0) {
+      h5_write_int  (m_file, ds_ext, lcpl, grp + "/end_processes", end_processes, log);
+      h5_write_int  (m_file, ds_ext, lcpl, grp + "/statuses",      statuses,      log);
+      h5_write_float(m_file, ds_ext, lcpl, grp + "/masses",        masses,        log);
+      h5_write_int  (m_file, ds_ext, lcpl, grp + "/ndaughters",    ndaughters,    log);
+      h5_write_int  (m_file, ds_ext, lcpl, grp + "/ntrajpts",      ntrajpts,      log);
+      H5Sclose(ds_ext);
+    }
+  }
+
+  H5Pclose(lcpl);
+  log->debug("TrackIDPIDMap2h5 wrote {} MCParticle entries to {}", n, grp);
+}
+
+void AIML::TrackIDPIDMap2h5::write_mapping_simchnl(int frame_ident)
+{
+  // Writes SimChannel-based truth (TPC ionizers, via ParticleInventoryService)
+  // under /<frame_ident>/simchnl/
+  if (m_file < 0 || m_simchnl_trackid_to_pid.empty()) { return; }
+
+  std::vector<int> track_ids;
+  track_ids.reserve(m_simchnl_trackid_to_pid.size());
+  for (auto const& entry : m_simchnl_trackid_to_pid) { track_ids.push_back(entry.first); }
+  std::sort(track_ids.begin(), track_ids.end());
+
+  const size_t n = track_ids.size();
+  std::vector<int>   pids(n), mother_ids(n), processes(n), mother_pids(n);
+  std::vector<float> energies(n);
+  for (size_t i = 0; i < n; ++i) {
+    int tid = track_ids[i];
+    pids[i]        = m_simchnl_trackid_to_pid.at(tid);
+    mother_ids[i]  = m_simchnl_trackid_to_motherid.count(tid)  ? m_simchnl_trackid_to_motherid.at(tid)  : 0;
+    processes[i]   = m_simchnl_trackid_to_process.count(tid)   ? m_simchnl_trackid_to_process.at(tid)   : -1;
+    mother_pids[i] = m_simchnl_trackid_to_motherpid.count(tid) ? m_simchnl_trackid_to_motherpid.at(tid) : 0;
+    energies[i]    = m_simchnl_trackid_to_energy.count(tid)    ? m_simchnl_trackid_to_energy.at(tid)    : 0.0f;
+  }
+
+  const hsize_t dims[1] = {n};
+  const std::string grp = "/" + std::to_string(frame_ident) + "/simchnl";
+  hid_t lcpl = H5Pcreate(H5P_LINK_CREATE);
+  H5Pset_create_intermediate_group(lcpl, 1);
+  hid_t dataspace = H5Screate_simple(1, dims, nullptr);
+  if (dataspace < 0) { H5Pclose(lcpl); return; }
+
+  h5_write_int  (m_file, dataspace, lcpl, grp + "/track_ids",   track_ids,   log);
+  h5_write_int  (m_file, dataspace, lcpl, grp + "/pids",        pids,        log);
+  h5_write_int  (m_file, dataspace, lcpl, grp + "/mother_ids",  mother_ids,  log);
+  h5_write_int  (m_file, dataspace, lcpl, grp + "/processes",   processes,   log);
+  h5_write_int  (m_file, dataspace, lcpl, grp + "/mother_pids", mother_pids, log);
+  h5_write_float(m_file, dataspace, lcpl, grp + "/energies",    energies,    log);
+
+  H5Sclose(dataspace);
+  H5Pclose(lcpl);
+  log->debug("TrackIDPIDMap2h5 wrote {} SimChannel entries to {}", n, grp);
+}
+
+// --- MC JSON output (CellTree-compatible format for BEE) ---
+
+std::string AIML::TrackIDPIDMap2h5::pdg_name(int pdg)
+{
+  // Common particles
+  switch (pdg) {
+    case  11: return "e-";
+    case -11: return "e+";
+    case  13: return "mu-";
+    case -13: return "mu+";
+    case  22: return "gamma";
+    case 111: return "pi0";
+    case 211: return "pi+";
+    case -211: return "pi-";
+    case 321: return "K+";
+    case -321: return "K-";
+    case 2112: return "neutron";
+    case 2212: return "proton";
+    case  12: return "nu_e";
+    case -12: return "anti_nu_e";
+    case  14: return "nu_mu";
+    case -14: return "anti_nu_mu";
+    case  16: return "nu_tau";
+    case -16: return "anti_nu_tau";
+    default: break;
+  }
+  // Nuclear codes: 10LZZZAAAI
+  if (pdg > 1000000000) {
+    int z = (pdg - 1000000000) / 10000;
+    int a = (pdg - 1000000000 - z * 10000) / 10;
+    const char* elem = "";
+    switch (z) {
+      case 1:  elem = "H";  break;
+      case 2:  elem = "He"; break;
+      case 6:  elem = "C";  break;
+      case 8:  elem = "O";  break;
+      case 14: elem = "Si"; break;
+      case 15: elem = "P";  break;
+      case 16: elem = "S";  break;
+      case 17: elem = "Cl"; break;
+      case 18: elem = "Ar"; break;
+      case 19: elem = "K";  break;
+      case 20: elem = "Ca"; break;
+      default: return std::to_string(pdg);
+    }
+    return std::string(elem) + "-" + std::to_string(a);
+  }
+  return std::to_string(pdg);
+}
+
+bool AIML::TrackIDPIDMap2h5::keep_mc(int tid) const
+{
+  auto pit = m_trackid_to_pid.find(tid);
+  if (pit == m_trackid_to_pid.end()) return false;
+  int pdg = pit->second;
+  int proc = m_trackid_to_process.count(tid) ? m_trackid_to_process.at(tid) : -1;
+
+  // Skip ionization and bremsstrahlung electrons (too many to display).
+  // Use our s_process_map codes: eIoni=2, muIoni=3, eBrem=4
+  if (proc == 2 || proc == 3 || proc == 4) return false;
+
+  // Compute KE in MeV from start momentum
+  double ke_mev = 0;
+  auto mit = m_trackid_to_startmom.find(tid);
+  if (mit != m_trackid_to_startmom.end()) {
+    const auto& mom = mit->second;
+    double E = mom[3];
+    double px = mom[0], py = mom[1], pz = mom[2];
+    double mass = std::sqrt(std::max(0.0, E*E - px*px - py*py - pz*pz));
+    ke_mev = (E - mass) * 1000.0;
+  }
+
+  double thresh_KE_em = 5.0;  // MeV for gamma/e+/e-
+  double thresh_KE_np = 50.0; // MeV for neutron/proton/nuclei
+
+  if (pdg == 22 || pdg == 11 || pdg == -11) {
+    return ke_mev >= thresh_KE_em;
+  }
+  else if (pdg == 2112 || pdg == 2212 || pdg > 1000000000) {
+    return ke_mev >= thresh_KE_np;
+  }
+  return true;
+}
+
+bool AIML::TrackIDPIDMap2h5::dump_mc_json_node(int tid, std::ostream& out) const
+{
+  if (m_trackid_to_pid.find(tid) == m_trackid_to_pid.end()) return false;
+  if (!keep_mc(tid)) return false;
+
+  int pdg = m_trackid_to_pid.at(tid);
+
+  // KE in MeV
+  int ke_mev = 0;
+  auto mit = m_trackid_to_startmom.find(tid);
+  if (mit != m_trackid_to_startmom.end()) {
+    const auto& mom = mit->second;
+    double E = mom[3];
+    double px = mom[0], py = mom[1], pz = mom[2];
+    double mass = std::sqrt(std::max(0.0, E*E - px*px - py*py - pz*pz));
+    ke_mev = static_cast<int>((E - mass) * 1000.0);
+  }
+
+  out << std::fixed << std::setprecision(1);
+  out << "{";
+  out << "\"id\":" << tid << ",";
+  out << "\"text\":\"" << pdg_name(pdg) << "  " << ke_mev << " MeV\",";
+  out << "\"data\":{";
+
+  // Trajectory points
+  auto tit = m_trackid_to_traj.find(tid);
+  if (tit != m_trackid_to_traj.end() && !tit->second.empty()) {
+    const auto& traj = tit->second;
+    out << "\"traj_x\":[";
+    for (size_t j = 0; j < traj.size(); ++j) { if (j) out << ","; out << traj[j][0]; }
+    out << "],\"traj_y\":[";
+    for (size_t j = 0; j < traj.size(); ++j) { if (j) out << ","; out << traj[j][1]; }
+    out << "],\"traj_z\":[";
+    for (size_t j = 0; j < traj.size(); ++j) { if (j) out << ","; out << traj[j][2]; }
+    out << "],";
+  }
+
+  // Start/end positions
+  auto sit = m_trackid_to_start.find(tid);
+  auto eit = m_trackid_to_end.find(tid);
+  if (sit != m_trackid_to_start.end()) {
+    out << "\"start\":[" << sit->second[0] << ", " << sit->second[1] << ", " << sit->second[2] << "],";
+  }
+  if (eit != m_trackid_to_end.end()) {
+    out << "\"end\":[" << eit->second[0] << ", " << eit->second[1] << ", " << eit->second[2] << "]";
+  }
+  out << "},";
+
+  // Children (daughters that pass KeepMC)
+  std::vector<int> saved_daughters;
+  auto dit = m_trackid_to_daughters.find(tid);
+  if (dit != m_trackid_to_daughters.end()) {
+    for (int d : dit->second) {
+      if (m_trackid_to_pid.count(d) && keep_mc(d)) {
+        saved_daughters.push_back(d);
+      }
+    }
+  }
+
+  out << "\"children\":[";
+  if (saved_daughters.empty()) {
+    out << "],";
+    out << "\"icon\":\"jstree-file\"";
+    out << "}";
+  }
+  else {
+    for (size_t j = 0; j < saved_daughters.size(); ++j) {
+      if (j) out << ",";
+      dump_mc_json_node(saved_daughters[j], out);
+    }
+    out << "]}";
+  }
+  return true;
+}
+
+void AIML::TrackIDPIDMap2h5::dump_mc_json(std::ostream& out) const
+{
+  // Find primaries (mother == 0) that pass KeepMC
+  std::vector<int> primaries;
+  for (auto const& [tid, motherid] : m_trackid_to_motherid) {
+    if (motherid == 0 && keep_mc(tid)) {
+      primaries.push_back(tid);
+    }
+  }
+  std::sort(primaries.begin(), primaries.end());
+
+  out << "[";
+  bool first = true;
+  for (int tid : primaries) {
+    std::ostringstream tmp;
+    if (dump_mc_json_node(tid, tmp)) {
+      if (!first) out << ", ";
+      out << tmp.str();
+      first = false;
+    }
+  }
+  out << "]";
+}
+
+void AIML::TrackIDPIDMap2h5::write_mc_json(int frame_ident)
+{
+  if (m_trackid_to_pid.empty()) return;
+
+  // Create bee/data/<frame_ident>/ directory tree (matching CellTree convention)
+  ::mkdir("bee", 0755);
+  ::mkdir("bee/data", 0755);
+  std::string subdir = "bee/data/" + std::to_string(frame_ident);
+  ::mkdir(subdir.c_str(), 0755);
+
+  std::string filename = subdir + "/" + std::to_string(frame_ident) + "-mc.json";
+  std::ofstream fout(filename);
+  if (!fout.is_open()) {
+    log->error("TrackIDPIDMap2h5 failed to open {} for writing", filename);
+    return;
+  }
+  dump_mc_json(fout);
+  fout.close();
+  log->info("TrackIDPIDMap2h5 wrote MC truth JSON to {}", filename);
+}

--- a/larwirecell/aiml/TrackIDPIDMap2h5.h
+++ b/larwirecell/aiml/TrackIDPIDMap2h5.h
@@ -52,40 +52,40 @@ namespace WireCell::AIML {
     std::string m_particle_label;
     std::string m_output_file;
     bool m_save_mc_json{false};
-    bool m_save_extended_mcpart{false};  // dump extra MCParticle fields to HDF5
+    bool m_save_extended_mcpart{false}; // dump extra MCParticle fields to HDF5
 
     std::vector<sim::SimChannel> m_simchannels;
 
     // --- MCParticle-based maps (all stored G4 tracks, regardless of TPC ionization) ---
     // Basic (always dumped):
-    std::unordered_map<int, int>   m_trackid_to_pid;        // PDG code
-    std::unordered_map<int, int>   m_trackid_to_motherid;   // parent track ID
-    std::unordered_map<int, int>   m_trackid_to_process;    // G4 creation process code
-    std::unordered_map<int, int>   m_trackid_to_motherpid;  // parent's PDG code
+    std::unordered_map<int, int> m_trackid_to_pid;       // PDG code
+    std::unordered_map<int, int> m_trackid_to_motherid;  // parent track ID
+    std::unordered_map<int, int> m_trackid_to_process;   // G4 creation process code
+    std::unordered_map<int, int> m_trackid_to_motherpid; // parent's PDG code
     // Start/end positions [x, y, z, t] in cm from MCParticle trajectory
-    std::unordered_map<int, std::array<float,4>> m_trackid_to_start;
-    std::unordered_map<int, std::array<float,4>> m_trackid_to_end;
+    std::unordered_map<int, std::array<float, 4>> m_trackid_to_start;
+    std::unordered_map<int, std::array<float, 4>> m_trackid_to_end;
     // Start/end momentum [px, py, pz, E] in GeV from MCParticle
-    std::unordered_map<int, std::array<float,4>> m_trackid_to_startmom;
-    std::unordered_map<int, std::array<float,4>> m_trackid_to_endmom;
+    std::unordered_map<int, std::array<float, 4>> m_trackid_to_startmom;
+    std::unordered_map<int, std::array<float, 4>> m_trackid_to_endmom;
     // Daughter track IDs
     std::unordered_map<int, std::vector<int>> m_trackid_to_daughters;
     // Trajectory points [x, y, z] for each track
-    std::unordered_map<int, std::vector<std::array<float,3>>> m_trackid_to_traj;
+    std::unordered_map<int, std::vector<std::array<float, 3>>> m_trackid_to_traj;
 
     // Extended (only when save_extended_mcpart is true):
-    std::unordered_map<int, int>   m_trackid_to_endprocess;  // G4 termination process code
-    std::unordered_map<int, int>   m_trackid_to_status;      // StatusCode (1=tracked)
-    std::unordered_map<int, float> m_trackid_to_mass;        // PDG mass [GeV]
-    std::unordered_map<int, int>   m_trackid_to_ndaughters;  // number of daughters
-    std::unordered_map<int, int>   m_trackid_to_ntrajpts;    // number of trajectory points
+    std::unordered_map<int, int> m_trackid_to_endprocess; // G4 termination process code
+    std::unordered_map<int, int> m_trackid_to_status;     // StatusCode (1=tracked)
+    std::unordered_map<int, float> m_trackid_to_mass;     // PDG mass [GeV]
+    std::unordered_map<int, int> m_trackid_to_ndaughters; // number of daughters
+    std::unordered_map<int, int> m_trackid_to_ntrajpts;   // number of trajectory points
 
     // --- SimChannel-based maps (only tracks that ionized in TPC, via ParticleInventoryService) ---
-    std::unordered_map<int, int>   m_simchnl_trackid_to_pid;       // PDG code from pi_serv
-    std::unordered_map<int, int>   m_simchnl_trackid_to_motherid;  // parent track ID from pi_serv
-    std::unordered_map<int, int>   m_simchnl_trackid_to_process;   // G4 process code from pi_serv
-    std::unordered_map<int, int>   m_simchnl_trackid_to_motherpid; // parent's PDG code from pi_serv
-    std::unordered_map<int, float> m_simchnl_trackid_to_energy;    // summed deposited energy [MeV]
+    std::unordered_map<int, int> m_simchnl_trackid_to_pid;       // PDG code from pi_serv
+    std::unordered_map<int, int> m_simchnl_trackid_to_motherid;  // parent track ID from pi_serv
+    std::unordered_map<int, int> m_simchnl_trackid_to_process;   // G4 process code from pi_serv
+    std::unordered_map<int, int> m_simchnl_trackid_to_motherpid; // parent's PDG code from pi_serv
+    std::unordered_map<int, float> m_simchnl_trackid_to_energy;  // summed deposited energy [MeV]
 
     // G4 process name → integer code (following CellTree convention)
     static const std::map<std::string, int> s_process_map;

--- a/larwirecell/aiml/TrackIDPIDMap2h5.h
+++ b/larwirecell/aiml/TrackIDPIDMap2h5.h
@@ -1,0 +1,97 @@
+#ifndef WIRECELL_AIML_TRACKIDPIDMAP2H5
+#define WIRECELL_AIML_TRACKIDPIDMAP2H5
+
+#include "WireCellAux/Logger.h"
+#include "WireCellIface/IConfigurable.h"
+#include "WireCellIface/IFrameFilter.h"
+#include "lardataobj/Simulation/SimChannel.h"
+#include "larwirecell/Interfaces/IArtEventVisitor.h"
+
+#include <array>
+#include <hdf5.h>
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace WireCell::AIML {
+  class TrackIDPIDMap2h5 : public Aux::Logger,
+                           public wcls::IArtEventVisitor,
+                           public IFrameFilter,
+                           public IConfigurable {
+  public:
+    TrackIDPIDMap2h5();
+    ~TrackIDPIDMap2h5() override;
+
+    // IFrameFilter
+    bool operator()(const input_pointer& in, output_pointer& out) override;
+
+    // IConfigurable
+    void configure(const WireCell::Configuration& config) override;
+    WireCell::Configuration default_configuration() const override;
+
+    // IArtEventVisitor
+    void visit(art::Event& event) override;
+
+  private:
+    void cache_simchannels(const std::vector<sim::SimChannel>& simchs);
+    void populate_trackid_pid_map();
+    void clear_cache();
+    void ensure_file();
+    void write_mapping(int frame_ident);
+    void write_mapping_simchnl(int frame_ident);
+    void write_mc_json(int frame_ident);
+
+    // JSON helpers (CellTree-compatible)
+    bool keep_mc(int tid) const;
+    static std::string pdg_name(int pdg);
+    bool dump_mc_json_node(int tid, std::ostream& out) const;
+    void dump_mc_json(std::ostream& out) const;
+
+    std::string m_simchannel_label;
+    std::string m_particle_label;
+    std::string m_output_file;
+    bool m_save_mc_json{false};
+    bool m_save_extended_mcpart{false};  // dump extra MCParticle fields to HDF5
+
+    std::vector<sim::SimChannel> m_simchannels;
+
+    // --- MCParticle-based maps (all stored G4 tracks, regardless of TPC ionization) ---
+    // Basic (always dumped):
+    std::unordered_map<int, int>   m_trackid_to_pid;        // PDG code
+    std::unordered_map<int, int>   m_trackid_to_motherid;   // parent track ID
+    std::unordered_map<int, int>   m_trackid_to_process;    // G4 creation process code
+    std::unordered_map<int, int>   m_trackid_to_motherpid;  // parent's PDG code
+    // Start/end positions [x, y, z, t] in cm from MCParticle trajectory
+    std::unordered_map<int, std::array<float,4>> m_trackid_to_start;
+    std::unordered_map<int, std::array<float,4>> m_trackid_to_end;
+    // Start/end momentum [px, py, pz, E] in GeV from MCParticle
+    std::unordered_map<int, std::array<float,4>> m_trackid_to_startmom;
+    std::unordered_map<int, std::array<float,4>> m_trackid_to_endmom;
+    // Daughter track IDs
+    std::unordered_map<int, std::vector<int>> m_trackid_to_daughters;
+    // Trajectory points [x, y, z] for each track
+    std::unordered_map<int, std::vector<std::array<float,3>>> m_trackid_to_traj;
+
+    // Extended (only when save_extended_mcpart is true):
+    std::unordered_map<int, int>   m_trackid_to_endprocess;  // G4 termination process code
+    std::unordered_map<int, int>   m_trackid_to_status;      // StatusCode (1=tracked)
+    std::unordered_map<int, float> m_trackid_to_mass;        // PDG mass [GeV]
+    std::unordered_map<int, int>   m_trackid_to_ndaughters;  // number of daughters
+    std::unordered_map<int, int>   m_trackid_to_ntrajpts;    // number of trajectory points
+
+    // --- SimChannel-based maps (only tracks that ionized in TPC, via ParticleInventoryService) ---
+    std::unordered_map<int, int>   m_simchnl_trackid_to_pid;       // PDG code from pi_serv
+    std::unordered_map<int, int>   m_simchnl_trackid_to_motherid;  // parent track ID from pi_serv
+    std::unordered_map<int, int>   m_simchnl_trackid_to_process;   // G4 process code from pi_serv
+    std::unordered_map<int, int>   m_simchnl_trackid_to_motherpid; // parent's PDG code from pi_serv
+    std::unordered_map<int, float> m_simchnl_trackid_to_energy;    // summed deposited energy [MeV]
+
+    // G4 process name → integer code (following CellTree convention)
+    static const std::map<std::string, int> s_process_map;
+
+    hid_t m_file;
+  };
+}
+
+#endif

--- a/larwirecell/aiml/Truth2h5.cxx
+++ b/larwirecell/aiml/Truth2h5.cxx
@@ -137,9 +137,11 @@ bool AIML::Truth2h5::operator()(const input_pointer& in, output_pointer& out)
 void AIML::Truth2h5::ensure_file()
 {
   if (m_file >= 0) { return; }
-  m_file = H5Fopen(m_output_file.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
+  // Create a fresh file at first use so datasets from a previous run in the
+  // same directory cannot collide; fall back to appending if create fails.
+  m_file = H5Fcreate(m_output_file.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
   if (m_file < 0) {
-    m_file = H5Fcreate(m_output_file.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    m_file = H5Fopen(m_output_file.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
     if (m_file < 0) { log->error("Truth2h5 failed to open output file {}", m_output_file); }
   }
 }


### PR DESCRIPTION

Add new WireCell component TrackIDPIDMap2h5 that reads MCParticle and SimChannel collections from art events and writes per-trackID truth metadata (PID, mother ID, G4 process, mother PID, energy fraction, and full MC ancestry chain) to HDF5.  This enables downstream pixel-level classification of Tracks, Showers, Michel electrons, Delta-rays, and Blips.

Extend Labelling2D to output energy fraction (1st/2nd contributor) and total numelectrons traces alongside existing label/trackid/pid frames.